### PR TITLE
Remove all global sc_events

### DIFF
--- a/src/sysc/communication/sc_event_finder.h
+++ b/src/sysc/communication/sc_event_finder.h
@@ -150,7 +150,7 @@ sc_event_finder_t<IF>::find_event( sc_interface* if_p ) const
                                  dynamic_cast<const IF*>( port().get_interface() );
     if( iface == 0 ) {
         report_error( SC_ID_FIND_EVENT_, "port is not bound" );
-        return sc_event::none;
+        return sc_event::none();
     }
     return (const_cast<IF*>( iface )->*m_event_method) ();
 }

--- a/src/sysc/communication/sc_interface.cpp
+++ b/src/sysc/communication/sc_interface.cpp
@@ -52,7 +52,7 @@ const sc_event&
 sc_interface::default_event() const
 {
     SC_REPORT_WARNING( SC_ID_NO_DEFAULT_EVENT_, 0 );
-    return sc_event::none;
+    return sc_event::none();
 }
 
 

--- a/src/sysc/kernel/sc_event.cpp
+++ b/src/sysc/kernel/sc_event.cpp
@@ -52,9 +52,6 @@ using std::strncmp;
 //  The event class.
 // ----------------------------------------------------------------------------
 
-// kernel-internal event, that is never notified
-const sc_event sc_event::none( kernel_event, "none" );
-
 const char*
 sc_event::basename() const
 {

--- a/src/sysc/kernel/sc_event.h
+++ b/src/sysc/kernel/sc_event.h
@@ -300,8 +300,13 @@ public:
     // has this event been triggered in the current delta cycle?
     bool triggered() const;
 
-    // never notified event
-    static const sc_event none;
+    // returns never notified event
+    static const sc_event& none(void) {
+        sc_simcontext *sc = sc_get_curr_simcontext();
+        if (!sc->m_none_event)
+            sc->m_none_event = new sc_event(sc_event::kernel_event, "none");
+        return *sc->m_none_event;
+    }
 
 private:
 

--- a/src/sysc/kernel/sc_process.cpp
+++ b/src/sysc/kernel/sc_process.cpp
@@ -47,7 +47,13 @@ namespace sc_core {
 
 std::vector<sc_event*>  sc_process_handle::empty_event_vector;
 std::vector<sc_object*> sc_process_handle::empty_object_vector;
-sc_event                sc_process_handle::non_event( sc_event::kernel_event );
+
+sc_event &sc_process_handle::non_event(void) const {
+    sc_simcontext *sc = sc_get_curr_simcontext();
+    if (!sc->m_non_event)
+        sc->m_non_event = new sc_event(sc_event::kernel_event);
+    return *sc->m_non_event;
+}
 
 // Last process that was created:
 

--- a/src/sysc/kernel/sc_process_handle.h
+++ b/src/sysc/kernel/sc_process_handle.h
@@ -147,9 +147,9 @@ class SC_API sc_process_handle {
     sc_process_b* m_target_p;   // Target for this object instance.
 
   protected:
-    static std::vector<sc_event*>  empty_event_vector;  // If m_target_p == 0.
-    static std::vector<sc_object*> empty_object_vector; // If m_target_p == 0.
-    static sc_event                non_event;           // If m_target_p == 0.
+    static std::vector<sc_event*>  empty_event_vector;    // If m_target_p == 0.
+    static std::vector<sc_object*> empty_object_vector;   // If m_target_p == 0.
+    sc_event&                      non_event(void) const; // If m_target_p == 0.
 };
 
 inline bool operator == (
@@ -401,7 +401,7 @@ inline sc_event& sc_process_handle::reset_event() const
     else
     {
         SC_REPORT_WARNING( SC_ID_EMPTY_PROCESS_HANDLE_, "reset()");
-        return sc_process_handle::non_event;
+        return sc_process_handle::non_event();
     }
 }
 
@@ -478,7 +478,7 @@ inline sc_event& sc_process_handle::terminated_event()
     else
     {
         SC_REPORT_WARNING( SC_ID_EMPTY_PROCESS_HANDLE_, "terminated_event()");
-        return sc_process_handle::non_event;
+        return sc_process_handle::non_event();
     }
 }
 

--- a/src/sysc/kernel/sc_simcontext.cpp
+++ b/src/sysc/kernel/sc_simcontext.cpp
@@ -359,6 +359,7 @@ sc_simcontext::init()
     m_cor = 0;
     m_reset_finder_q = 0;
     m_none_event = NULL;
+    m_non_event = NULL;
     m_in_simulator_control = false;
     m_start_of_simulation_called = false;
     m_end_of_simulation_called = false;
@@ -399,6 +400,9 @@ sc_simcontext::clean()
         m_reset_finder_q = rf->m_next_p;
         delete rf;
     }
+
+    if (m_non_event)
+        delete m_non_event;
 }
 
 

--- a/src/sysc/kernel/sc_simcontext.cpp
+++ b/src/sysc/kernel/sc_simcontext.cpp
@@ -358,6 +358,7 @@ sc_simcontext::init()
     m_method_invoker_p = NULL;
     m_cor = 0;
     m_reset_finder_q = 0;
+    m_none_event = NULL;
     m_in_simulator_control = false;
     m_start_of_simulation_called = false;
     m_end_of_simulation_called = false;
@@ -369,6 +370,9 @@ sc_simcontext::clean()
 {
     // remove remaining zombie processes
     do_collect_processes();
+
+    if (m_none_event)
+        delete m_none_event;
 
     delete m_method_invoker_p;
     delete m_error;

--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -399,6 +399,8 @@ private:
 
     sc_reset_finder*            m_reset_finder_q; // Q of reset finders to reconcile.
 
+    sc_event*                   m_none_event; // never notified event
+
 private:
 
     // disabled

--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -400,6 +400,7 @@ private:
     sc_reset_finder*            m_reset_finder_q; // Q of reset finders to reconcile.
 
     sc_event*                   m_none_event; // never notified event
+    sc_event*                   m_non_event;  // used by sc_process_handle if m_target_p == 0
 
 private:
 

--- a/src/tlm_core/tlm_1/tlm_req_rsp/tlm_ports/tlm_event_finder.h
+++ b/src/tlm_core/tlm_1/tlm_req_rsp/tlm_ports/tlm_event_finder.h
@@ -66,7 +66,7 @@ tlm_event_finder_t<IF,T>::find_event( sc_core::sc_interface* if_p ) const
                                  dynamic_cast<const IF*>( port().get_interface() );
     if( iface == 0 ) {
         report_error( sc_core::SC_ID_FIND_EVENT_, "port is not bound" );
-        return sc_core::sc_event::none;
+        return sc_core::sc_event::none();
     }
     return (const_cast<IF*>( iface )->*m_event_method) ( 0 );
 }


### PR DESCRIPTION
The changes proposed here remove all(?) global `sc_event`s (`sc_event::none` and `sc_process_handle::non_event`) by converting them to functions returning a reference to an `sc_event` in the current simulation context. This eases reset of the simulation context, as discussed in #8, as these `sc_event`s no longer contain any reference to the initial simulation context.

A useful side effect of these changes: Previously the simulation context was created on program startup by the `sc_event` constructor (through the invocation of `sc_get_curr_simcontext()`) by the aforementioned global `sc_event`s. With these changes applied it is created on the first invocation of `sc_get_curr_simcontext()`.

It is currently unclear to me if it would be possible to return the same reference for `sc_event::none()` and `sc_process_handle::non_event()`, currently two different class members in the `sc_simcontext` are used.

To the best of my knowledge neither `sc_event::none` nor `sc_process_handle::non_event` are mandated by IEEE Std 1666-2011. For this reason, the proposed changes should not affect existing standard-conforming SystemC programs.