### PR TITLE
Remove call to sc_abort() from sc_assertion_failed()

### DIFF
--- a/src/sysc/utils/sc_report_handler.cpp
+++ b/src/sysc/utils/sc_report_handler.cpp
@@ -840,7 +840,6 @@ sc_assertion_failed(const char* msg, const char* file, int line)
 {
     sc_report_handler::report( SC_FATAL, SC_ID_ASSERTION_FAILED_
                              , msg, file, line );
-    sc_abort();
 }
 
 } // namespace sc_core


### PR DESCRIPTION
sc_assertion_failed() calls the default report handler which in turn
will call sc_abort() if the SC_ABORT action is set.

Currently, it is not possible to avoid calling sc_abort() even when
setting the SC_FATAL report actions to SC_DO_NOTHING.

When using SystemC with Verilator, an abort causes no trace to be
written and therefore makes sc_assert() unusable for runtime checks.