### PR TITLE
Don't use `force_align_arg_pointer` on non-x86 platforms

### DIFF
--- a/src/sysc/kernel/sc_thread_process.cpp
+++ b/src/sysc/kernel/sc_thread_process.cpp
@@ -83,7 +83,7 @@
 // force 16-byte alignment on coroutine entry functions, needed for
 // QuickThreads (32-bit, see also fixes in qt/md/{i386,iX86_64}.[hs]),
 // and MinGW32 / Cygwin32 compilers on Windows platforms
-#if defined(__GNUC__) && !defined(__ICC) && !defined(__x86_64__) && \
+#if defined(__GNUC__) && !defined(__ICC) && defined(__i386__) && \
     (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 1 )
 # define SC_ALIGNED_STACK_ \
     __attribute__((force_align_arg_pointer))


### PR DESCRIPTION
Currently, `SC_ALIGNED_STACK_` is defined to `__attribute__((force_align_arg_pointer))` on any platform that's not x86_64, but this attribute only exists for the gcc/clang x86 backends (https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html). With this change, the attribute is only used on i386, and not on other platforms (e.g. aarch64) where it would be unexpected.

Signed-off-by: Lexi Bromfield <lexinadia@google.com>