### PR TITLE
Switch file encoding to UTF-8

### DIFF
--- a/examples/tlm/at_2_phase/src/at_2_phase.cpp
+++ b/examples/tlm/at_2_phase/src/at_2_phase.cpp
@@ -47,7 +47,7 @@
 ///  @details
 ///    This is the SystemC entry point for the example system.  The argc and argv 
 ///    parameters are not used.  Simulation runtime is not specified when 
-///    “sc_start()” is called, the example’s traffic generator will run to 
+///    â€œsc_start()â€œ is called, the exampleâ€™s traffic generator will run to 
 ///    completion, ending the simulation. 
 ///
 //=====================================================================

--- a/examples/tlm/at_4_phase/src/at_4_phase.cpp
+++ b/examples/tlm/at_4_phase/src/at_4_phase.cpp
@@ -47,7 +47,7 @@
 ///  @details
 ///    This is the SystemC entry point for the example system.  The argc and argv 
 ///    parameters are not used.  Simulation runtime is not specified when 
-///    “sc_start()” is called, the example’s traffic generator will run to 
+///    â€œsc_start()â€œ is called, the exampleâ€™s traffic generator will run to 
 ///    completion, ending the simulation. 
 ///
 //=====================================================================

--- a/examples/tlm/at_extension_optional/src/at_extension_optional.cpp
+++ b/examples/tlm/at_extension_optional/src/at_extension_optional.cpp
@@ -46,7 +46,7 @@
 ///  @details
 ///    This is the SystemC entry point for the example system.  The argc and argv 
 ///    parameters are not used.  Simulation runtime is not specified when 
-///    “sc_start()” is called, the example’s traffic generator will run to 
+///    â€œsc_start()â€œ is called, the exampleâ€™s traffic generator will run to 
 ///    completion, ending the simulation. 
 ///
 //=====================================================================

--- a/examples/tlm/at_mixed_targets/src/at_mixed_targets.cpp
+++ b/examples/tlm/at_mixed_targets/src/at_mixed_targets.cpp
@@ -49,7 +49,7 @@ using namespace sc_core;
 ///  @details
 ///    This is the SystemC entry point for the example system.  The argc and argv 
 ///    parameters are not used.  Simulation runtime is not specified when 
-///    “sc_start()” is called, the example’s traffic generator will run to 
+///    â€œsc_start()â€œ is called, the exampleâ€™s traffic generator will run to 
 ///    completion, ending the simulation. 
 ///
 //=====================================================================

--- a/examples/tlm/at_ooo/src/at_ooo.cpp
+++ b/examples/tlm/at_ooo/src/at_ooo.cpp
@@ -47,7 +47,7 @@
 ///  @details
 ///    This is the SystemC entry point for the example system.  The argc and argv 
 ///    parameters are not used.  Simulation runtime is not specified when 
-///    “sc_start()” is called, the example’s traffic generator will run to 
+///    â€œsc_start()â€œ is called, the exampleâ€™s traffic generator will run to 
 ///    completion, ending the simulation. 
 ///
 //=====================================================================

--- a/examples/tlm/common/src/traffic_generator.cpp
+++ b/examples/tlm/common/src/traffic_generator.cpp
@@ -249,8 +249,8 @@ void traffic_generator::check_complete (void)
       unsigned int    read_data       = *reinterpret_cast<unsigned int*>(data_buffer_ptr);
     
       //-----------------------------------------------------------------------------
-      // The address for the “gp” is used as expected data.  The address filed of 
-      //  the “gp” is a mutable field and is changed by the SimpleBus interconnect. 
+      // The address for the gp is used as expected data.  The address filed of 
+      //  the gp is a mutable field and is changed by the SimpleBus interconnect. 
       //  The list significant 28 bits are not modified and are use for comparison.    
 
       const unsigned int data_mask ( 0x0FFFFFFF );

--- a/src/sysc/packages/boost/config/compiler/sunpro_cc.hpp
+++ b/src/sysc/packages/boost/config/compiler/sunpro_cc.hpp
@@ -40,7 +40,7 @@
        // initialized in-class.
        //    >> Assertion:   (../links/dbg_cstabs.cc, line 611)
        //         while processing ../test.cpp at line 0.
-       // (Jens Maurer according to Gottfried Ganﬂauge 04 Mar 2002)
+       // (Jens Maurer according to Gottfried Gan√üauge 04 Mar 2002)
 #      define SC_BOOST_NO_INCLASS_MEMBER_INITIALIZATION
 
        // SunPro 5.3 has better support for partial specialization,

--- a/src/sysc/packages/boost/config/compiler/vacpp.hpp
+++ b/src/sysc/packages/boost/config/compiler/vacpp.hpp
@@ -1,7 +1,7 @@
 //  (C) Copyright John Maddock 2001 - 2003. 
 //  (C) Copyright Toon Knapen 2001 - 2003. 
 //  (C) Copyright Lie-Quan Lee 2001. 
-//  (C) Copyright Markus Schöpflin 2002 - 2003. 
+//  (C) Copyright Markus SchÃ¶pflin 2002 - 2003. 
 //  (C) Copyright Beman Dawes 2002 - 2003. 
 //  Use, modification and distribution are subject to the 
 //  Boost Software License, Version 1.0. (See accompanying file 

--- a/src/sysc/packages/boost/ref.hpp
+++ b/src/sysc/packages/boost/ref.hpp
@@ -14,7 +14,7 @@
 //
 //  ref.hpp - ref/cref, useful helper functions
 //
-//  Copyright (C) 1999, 2000 Jaakko Järvi (jaakko.jarvi@cs.utu.fi)
+//  Copyright (C) 1999, 2000 Jaakko JÃ¤rvi (jaakko.jarvi@cs.utu.fi)
 //  Copyright (C) 2001, 2002 Peter Dimov
 //  Copyright (C) 2002 David Abrahams
 //

--- a/src/sysc/packages/boost/utility/enable_if.hpp
+++ b/src/sysc/packages/boost/utility/enable_if.hpp
@@ -1,12 +1,12 @@
 // Boost enable_if library
 
-// Copyright 2003 © The Trustees of Indiana University.
+// Copyright 2003 Â© The Trustees of Indiana University.
 
 // Use, modification, and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-//    Authors: Jaakko Järvi (jajarvi at osl.iu.edu)
+//    Authors: Jaakko JÃ¤rvi (jajarvi at osl.iu.edu)
 //             Jeremiah Willcock (jewillco at osl.iu.edu)
 //             Andrew Lumsdaine (lums at osl.iu.edu)
 

--- a/src/sysc/packages/boost/utility/string_view.hpp
+++ b/src/sysc/packages/boost/utility/string_view.hpp
@@ -1,6 +1,6 @@
 /*
-   © Copyright (c) Marshall Clow 2012-2015.
-   © Copyright Beman Dawes 2015
+   Â© Copyright (c) Marshall Clow 2012-2015.
+   Â© Copyright Beman Dawes 2015
 
    Distributed under the Boost Software License, Version 1.0. (See accompanying
    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Some files within the source did have a file encoding of ISO-8859-15 which is a national encoding and might provoke sometimes suspicious issues.

That was detected by Lintian, a Debian QA tool for detecting issues within Debian packages.

https://lintian.debian.org/tags/national-encoding
https://udd.debian.org/lintian/?packages=systemc
