### PR TITLE
examples/sysc/2.3/simple_async needs PTHREADS

### DIFF
--- a/examples/sysc/2.3/simple_async/Makefile
+++ b/examples/sysc/2.3/simple_async/Makefile
@@ -4,4 +4,6 @@ include ../../../build-unix/Makefile.config
 PROJECT = simple_async
 OBJS    = main.o
 
+PTHREADS = 1
+
 include ../../../build-unix/Makefile.rules


### PR DESCRIPTION
The gnu Makefile for that example needs to set `PTHREADS=1` or it will fail to build when systemc is configured `--enable-pthreads`