### PR TITLE
Enable shared library build without global flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,6 @@
 # respectively). Each variable is annotated with a brief documentation string.
 # The most important variables are:
 #
-# BUILD_SHARED_LIBS             Build shared instead of static libraries
-#                               (default: ON if not targetting Windows).
-#
 # BUILD_SOURCE_DOCUMENTATION    Build source code documentation using Doxygen
 #                               (default: OFF).
 #
@@ -135,6 +132,9 @@
 #
 # OVERRIDE_DEFAULT_STACK_SIZE   Define the default stack size used for SystemC
 #                               (thread) processes. (> 0)
+#
+# SYSTEMC_BUILD_SHARED_LIBS     Build shared instead of static libraries
+#                               (default: ON if not targeting Windows).
 #
 # SystemC_TARGET_ARCH           Target architecture according to the
 #                               Accellera SystemC conventions set either from
@@ -258,14 +258,19 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 if (NOT (WIN32 OR CYGWIN))
-  option (BUILD_SHARED_LIBS "Build shared libraries." ON)
+  option (SYSTEMC_BUILD_SHARED_LIBS "Build shared libraries." ON)
 else (NOT (WIN32 OR CYGWIN))
-  option (BUILD_SHARED_LIBS "Build shared libraries." OFF)
+  option (SYSTEMC_BUILD_SHARED_LIBS "Build shared libraries." OFF)
 endif (NOT (WIN32 OR CYGWIN))
-if (BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN))
-  message (WARNING "The compilation of SystemC as a DLL on Windows is currently not supported!")
-  set (BUILD_SHARED_LIBS CACHE BOOL "Build shared libraries." OFF FORCE)
-endif (BUILD_SHARED_LIBS AND (WIN32 OR CYGWIN))
+
+set(SC_LIB_TYPE STATIC)
+if (SYSTEMC_BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+  if (WIN32 OR CYGWIN)
+    message (FATAL_ERROR "The compilation of SystemC as a DLL on Windows is currently not supported!")
+  else ()
+    set(SC_LIB_TYPE SHARED)
+  endif ()
+endif ()
 
 option (BUILD_SOURCE_DOCUMENTATION "Build source documentation with Doxygen." OFF)
 
@@ -603,7 +608,7 @@ endif ("${isSystemDir}" STREQUAL "-1")
 message (STATUS "========================================================================")
 message (STATUS "Settings to build SystemC ${SystemCLanguage_VERSION} (${SystemCLanguage_VERSION_RELEASE_DATE}) and TLM ${SystemCTLM_VERSION} (${SystemCTLM_VERSION_RELEASE_DATE})")
 message (STATUS "------------------------------------------------------------------------")
-message (STATUS "BUILD_SHARED_LIBS = ${BUILD_SHARED_LIBS}")
+message (STATUS "SYSTEMC_BUILD_SHARED_LIBS = ${SYSTEMC_BUILD_SHARED_LIBS}")
 message (STATUS "BUILD_SOURCE_DOCUMENTATION = ${BUILD_SOURCE_DOCUMENTATION}")
 message (STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 message (STATUS "DISABLE_COPYRIGHT_MESSAGE = ${DISABLE_COPYRIGHT_MESSAGE}")

--- a/cmake/INSTALL_USING_CMAKE
+++ b/cmake/INSTALL_USING_CMAKE
@@ -146,9 +146,6 @@ variables offered to the user in the CMake console and GUI (ccmake and
 cmake-gui, respectively). Each variable is annotated with a brief
 documentation string. The most important variables are:
 
-BUILD_SHARED_LIBS             Build shared instead of static libraries
-                              (default: ON if not targetting Windows).
-
 BUILD_SOURCE_DOCUMENTATION    Build source code documentation using Doxygen
                               (default: OFF).
 
@@ -192,6 +189,9 @@ ENABLE_IMMEDIATE_SELF_NOTIFICATIONS  Enable immediate self-notification of
 
 ENABLE_PTHREADS               Use POSIX threads for SystemC processes instead
                               of QuickThreads on Unix or Fiber on Windows.
+
+SYSTEMC_BUILD_SHARED_LIBS     Build shared instead of static libraries
+                              (default: ON if not targeting Windows).
 
 SystemC_TARGET_ARCH           Target architecture according to the
                               Accellera SystemC conventions set either from

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,7 @@ endif (QT_ARCH STREQUAL "sparc")
 # Build rules for SystemC library
 ###############################################################################
 
-add_library (systemc sysc/communication/sc_clock.cpp
+add_library (systemc ${SC_LIB_TYPE} sysc/communication/sc_clock.cpp
                      sysc/communication/sc_event_finder.cpp
                      sysc/communication/sc_event_queue.cpp
                      sysc/communication/sc_export.cpp
@@ -451,7 +451,7 @@ target_compile_definitions (
   PUBLIC
   $<$<BOOL:${DISABLE_VIRTUAL_BIND}>:SC_DISABLE_VIRTUAL_BIND>
   $<$<BOOL:${WIN32}>:WIN32>
-  $<$<AND:$<BOOL:${BUILD_SHARED_LIBS}>,$<OR:$<BOOL:${WIN32}>,$<BOOL:${CYGWIN}>>>:
+  $<$<AND:$<STREQUAL:${SC_LIB_TYPE},SHARED>,$<OR:$<BOOL:${WIN32}>,$<BOOL:${CYGWIN}>>>:
     SC_WIN_DLL>
   $<$<BOOL:${ALLOW_DEPRECATED_IEEE_API}>:SC_ALLOW_DEPRECATED_IEEE_API>
   PRIVATE


### PR DESCRIPTION
SystemC's CMakeLists.txt used to rely on the global BUILD_SHARED_LIBS flag to enable building SystemC as a shared library. This also forces all other libraries in the project to be build as shared libraries. This commit enables the user to select only SystemC to be build as a shared library without forcing this on all other libraries in the cmake project.