### PR TITLE
Add GitHub Actions for building SystemC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,50 @@
+name: cmake
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'dev**'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build_ubuntu:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        version: [20.04, 22.04]
+        platform: [linux/amd64, linux/arm64]
+    steps:
+    - name: Install qemu-user-static
+      run: |
+        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
+          sudo apt-get install qemu-user-static
+        fi
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
+        docker run systemc_test
+  build_almalinux:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        version: [8, 9]
+        platform: [linux/amd64, linux/arm64]
+    steps:
+    - name: Install qemu-user-static
+      run: |
+        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
+          sudo apt-get install qemu-user-static
+        fi
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build
+      run: |
+        docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
+        docker run systemc_test

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -72,6 +72,7 @@
  * Fraunhofer-Gesellschaft
  * GreenSocs
  * Intel Corporation
+ * MachineWare GmbH
  * Mentor Graphics Corporation
  * NXP Semiconductors
  * OFFIS eV

--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,11 @@ This product includes software developed by Intel Corp.
 Copyright 2007-2019 Intel Corp.
 All rights reserved.
 
+This product includes software developed by MachineWare GmbH
+Hühnermarkt 19, 52062 Aachen, Germany
+Copyright 2022-2023 MachineWare GmbH
+All rights reserved.
+
 This product includes software developed by Mentor Graphics Corporation
 8005 SW Boeckman Road, Wilsonville, OR 97070, USA
 Copyright 2006-2019 Mentor Graphics Corporation

--- a/docker/alma.dockerfile
+++ b/docker/alma.dockerfile
@@ -1,0 +1,20 @@
+ARG ALMA_VERSION=8
+ARG IMAGE=almalinux:$ALMA_VERSION
+
+FROM $IMAGE
+
+WORKDIR /app
+
+RUN dnf install -y \
+    cmake \
+    gcc \
+    gcc-c++ \
+    && dnf clean all
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+RUN cmake -B BUILD/RELEASE/BUILD -DCMAKE_INSTALL_PREFIX=$PWD/BUILD/RELEASE .
+RUN cmake --build BUILD/RELEASE/BUILD/ --parallel
+
+CMD ["/bin/bash", "-c", "make -j `nproc` -C BUILD/RELEASE/BUILD/ check"]

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -1,0 +1,21 @@
+ARG UBUNTU_VERSION=20.04
+ARG IMAGE=ubuntu:$UBUNTU_VERSION
+
+FROM $IMAGE
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y \
+    cmake \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+RUN cmake -B BUILD/RELEASE/BUILD -DCMAKE_INSTALL_PREFIX=$PWD/BUILD/RELEASE .
+RUN cmake --build BUILD/RELEASE/BUILD/ --parallel
+
+CMD ["/bin/bash", "-c", "make -j `nproc` -C BUILD/RELEASE/BUILD/ check"]


### PR DESCRIPTION
Adding CI flow that builds the examples for Ubuntu 20.04 and 22.04 and AlmaLinux 8 and 9 on AMD64 and ARM64 (using QEMU on x86 runner)