### PR TITLE
Fix for installing non-existent doc files (#66)

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -48,7 +48,8 @@ foreach (DOC_FILE ${DOC_FILES})
   get_filename_component (DOC_INSTALL_PATH ${DOC_FILE} PATH)
   install (FILES ${DOC_FILE}
            DESTINATION ${CMAKE_INSTALL_DOCDIR}/${DOC_INSTALL_PATH}
-           COMPONENT doc)
+           COMPONENT doc
+           OPTIONAL)
 endforeach (DOC_FILE ${DOC_FILES})
 
 if (BUILD_SOURCE_DOCUMENTATION)


### PR DESCRIPTION
This patch addresses #66 and does two things:

1. it removes `docs/DEVELOPMENT.md`, which points to inaccessible OSCI private repo
2. it add `OPTIONAL` to cmake install, so that it does not fail when trying to install `docs/DEVELOPMENT.md`