### PR TITLE
Restore hierarchy helper API to public

### DIFF
--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -330,11 +330,11 @@ public:
     void pre_suspend() const;
     void post_suspend() const;
 
-private:
     void hierarchy_push(sc_object_host*);
     sc_object_host* hierarchy_pop();
     sc_object_host* hierarchy_curr() const;
 
+private:
     void add_child_event( sc_event* );
     void add_child_object( sc_object* );
     void remove_child_event( sc_event* );


### PR DESCRIPTION
VCML requires access to `hierarchy_curr`, `hierarchy_pop` and `hierarchy_push` APIs. Please consider making them public again for SystemC 3.0.0.