### PR TITLE
Fix CI script

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,12 +2,7 @@ name: cmake
 
 on:
   push:
-    branches:
-      - 'main'
-      - 'dev**'
   pull_request:
-    branches:
-      - 'main'
 
 jobs:
   build_ubuntu:
@@ -21,7 +16,7 @@ jobs:
     - name: Install qemu-user-static
       run: |
         if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get install qemu-user-static
+          sudo apt-get update && sudo apt-get install -y qemu-user-static
         fi
     - name: Checkout
       uses: actions/checkout@v4
@@ -40,7 +35,7 @@ jobs:
     - name: Install qemu-user-static
       run: |
         if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get install qemu-user-static
+          sudo apt-get update && sudo apt-get install -y qemu-user-static
         fi
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
The CI script was tied to incorrect branch names.
This commit removes these restrictions.
Also there was an issue with updating the apt cache on the CI host before installing qemu-user-static for the arm64 builds.