### PR TITLE
Fix build by removing non-existent dependencies

### DIFF
--- a/examples/sysc/2.1/forkjoin/test.am
+++ b/examples/sysc/2.1/forkjoin/test.am
@@ -84,8 +84,7 @@ examples_DIRS += 2.1/forkjoin
 	2.1/forkjoin/forkjoin.sln \
 	2.1/forkjoin/forkjoin.vcxproj \
 	2.1/forkjoin/CMakeLists.txt \
-	2.1/forkjoin/Makefile \
-	2.1/forkjoin/README.txt
+	2.1/forkjoin/Makefile
 
 #2_1_forkjoin_FILTER = 
 


### PR DESCRIPTION
The file examples/sysc/2.1/forkjoin/README.txt has been deleted by [8c41627](https://github.com/accellera-official/systemc/commit/8c41627e84291060130db64119ed6e5091f4a32e)