### PR TITLE
Fix crash when writing empty trace files with debug assertions on

### DIFF
--- a/src/sysc/tracing/sc_vcd_trace.cpp
+++ b/src/sysc/tracing/sc_vcd_trace.cpp
@@ -1374,9 +1374,8 @@ vcd_trace_file::cycle(bool this_is_a_delta_cycle)
 
     // Now do the actual printing
     bool time_printed = false;
-    vcd_trace* const* const l_traces = &traces[0];
-    for (int i = 0; i < (int)traces.size(); i++) {
-        vcd_trace* t = l_traces[i];
+    for (size_t i = 0; i < traces.size(); i++) {
+        vcd_trace* t = traces[i];
         if(t->changed()) {
             if(!time_printed){
                 print_time_stamp(now_units_high, now_units_low);

--- a/src/sysc/tracing/sc_wif_trace.cpp
+++ b/src/sysc/tracing/sc_wif_trace.cpp
@@ -1226,9 +1226,8 @@ wif_trace_file::cycle(bool this_is_a_delta_cycle)
     }
 
     bool time_printed = false;
-    wif_trace* const* const l_traces = &traces[0];
-    for (int i = 0; i < (int)traces.size(); i++) {
-        wif_trace* t = l_traces[i];
+    for (size_t i = 0; i < traces.size(); i++) {
+        wif_trace* t = traces[i];
         if(t->changed()){
             if(time_printed == false) {
 


### PR DESCRIPTION
Using &traces[0] with an empty traces vector will cause some std::vector implementations to cause a debug assertion.

If the original way of using a raw pointer to the content of the vector should be restored, std::vector::data would also work for empty containers.

Also removes casting the vector size to int and uses the correct data type.