### PR TITLE
ci: disable regressions and sanitizers on QEMU ARM64, too slow

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -11,14 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [20.04, 22.04]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-asan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
@@ -31,14 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [8, 9]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-asan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -11,14 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [20.04, 22.04]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
@@ -31,14 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [8, 9]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -11,14 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [20.04, 22.04]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-tsan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
@@ -31,14 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [8, 9]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-tsan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -11,14 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [20.04, 22.04]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-ubsan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build
@@ -31,14 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         version: [8, 9]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
         target: [clang-shared-regression-ubsan]
     steps:
-    - name: Install qemu-user-static
-      run: |
-        if [[ "${{ matrix.platform }}" == "linux/arm64" ]]; then
-          sudo apt-get update && sudo apt-get install -y qemu-user-static
-        fi
     - name: Checkout
       uses: actions/checkout@v4
     - name: Build


### PR DESCRIPTION
Regression and sanitizer runs take too long on QEMU ARM64.
Hopefully, we will have ARM64 Linux runners soon.
Linux build is still tested using QEMU ARM64.
ARM64 regressions are running on MacOS.