### PR TITLE
Add an argument to sc_stop, default to EXIT_SUCCESS, and provide sc_exit_status() to retrieve it

### DIFF
--- a/src/sysc/kernel/sc_simcontext.cpp
+++ b/src/sysc/kernel/sc_simcontext.cpp
@@ -1761,10 +1761,16 @@ sc_start()
               SC_EXIT_ON_STARVATION );
 }
 
+static int g_exit = EXIT_SUCCESS;
+SC_API int
+sc_exit_code() {
+    return g_exit;
+}
 
 SC_API void
-sc_stop()
+sc_stop(int exit_code)
 {
+    if (g_exit!=EXIT_SUCCESS) g_exit = exit_code;
     sc_get_curr_simcontext()->stop();
 }
 

--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -119,7 +119,8 @@ inline void sc_start( double duration, sc_time_unit unit,
     sc_start( sc_time(duration,unit), p );
 }
 
-extern SC_API void sc_stop();
+extern SC_API void sc_stop(int exit_code = EXIT_SUCCESS);
+extern SC_API int sc_exit_code();
 
 // friend function declarations
 


### PR DESCRIPTION
See documentation here:

https://github.com/OSCI-WG/lwg-documentation/pull/4