### PR TITLE
Add SYSTEMC_UNITY_BUILD CMake option and require CMake 3.16+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -405,7 +405,7 @@ As an example, here is a minimal `CMakeLists.txt` to compile the `simple_perf`
 SystemC example as a stand-alone application:
 
       --- Start: CMakeLists.txt ---
-      cmake_minimum_required(VERSION 3.5)
+      cmake_minimum_required(VERSION 3.16)
       project(simple_perf CXX)
 
       set (CMAKE_PREFIX_PATH /opt/systemc)

--- a/cmake/run-example.cmake
+++ b/cmake/run-example.cmake
@@ -38,7 +38,7 @@
 ###############################################################################
 
 
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.16...3.31)
 
 if(NOT TEST_EXE)
   message(FATAL_ERROR "  Usage: cmake -DTEST_EXE=<executable> [-DTEST_INPUT=<input-file>] \\\n"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,11 +38,13 @@
 #
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.8...3.31)
+cmake_minimum_required(VERSION 3.16...3.31)
 
 ###############################################################################
 # Build rules for SystemC library
 ###############################################################################
+
+option(SYSTEMC_UNITY_BUILD "Enable unity build" OFF)
 
 function(add_systemc_library libName scBuildDefine)
 
@@ -123,6 +125,14 @@ function(add_systemc_library libName scBuildDefine)
         VERSION ${SystemCLanguage_VERSION}
         SOVERSION ${SystemCLanguage_SOVERSION}
         )
+
+    if(SYSTEMC_UNITY_BUILD)
+      message(STATUS "Enable SystemC unity build")
+      set_target_properties(${libName} PROPERTIES UNITY_BUILD ON)
+      set_source_files_properties(sysc/utils/sc_utils_ids.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    else()
+      message(STATUS "Disable SystemC unity build")
+    endif()
 
 endfunction(add_systemc_library)
 

--- a/src/sysc/datatypes/fx/sc_fxnum.cpp
+++ b/src/sysc/datatypes/fx/sc_fxnum.cpp
@@ -664,7 +664,7 @@ to_string( const scfx_ieee_double&,
 	   sc_numrep,
 	   int,
 	   sc_fmt,
-	   const scfx_params* = 0 );
+	   const scfx_params*);
 
 
 // explicit conversion to character string


### PR DESCRIPTION
This patch introduces a new CMake option -DSYSTEMC_UNITY_BUILD=ON to enable unity builds for the SystemC library, which may improve build performance in some environments.

Enabling this option compiles the sources as a single compilation unit. The option is OFF by default and does not affect standard builds.

The minimum required CMake version is raised to 3.16 to support this feature.

Rationale

Unity builds can significantly reduce build time in some build environments, especially those with many small translation units or slower filesystems.

CMake 3.16 is the first version that supports the required features (specifically UNITY_BUILD mode via target_sources() and target_sources(FILE_SET) logic).

Tested on

- MSVC
- Fedora 41 with Clang 15, 16, and 19 and GCC 12, 13, and 14
- Tested both with SYSTEMC_UNITY_BUILD=ON and OFF

Build times were roughly halved by turning on the build option.