### PR TITLE
sc_signed: Use auto type on save/restore old flags

### DIFF
--- a/src/sysc/datatypes/int/sc_signed.cpp
+++ b/src/sysc/datatypes/int/sc_signed.cpp
@@ -575,11 +575,7 @@ void
 sc_signed::dump(::std::ostream& os) const
 {
   // Save the current setting, and set the base to decimal.
-#if defined(__MINGW32__)
-  std::_Ios_Fmtflags old_flags = os.setf(::std::ios::dec,::std::ios::basefield);
-#else
-  fmtflags old_flags = os.setf(::std::ios::dec, ::std::ios::basefield);
-#endif
+  auto old_flags = os.setf(::std::ios::dec, ::std::ios::basefield);
 
   os << "width = " << length() << ::std::endl;
   os << "value = " << *this << ::std::endl;

--- a/src/sysc/datatypes/int/sc_unsigned.cpp
+++ b/src/sysc/datatypes/int/sc_unsigned.cpp
@@ -554,11 +554,7 @@ void
 sc_unsigned::dump(::std::ostream& os) const
 {
   // Save the current setting, and set the base to decimal.
-#if defined(__MINGW32__)
-  std::_Ios_Fmtflags old_flags = os.setf(::std::ios::dec,::std::ios::basefield);
-#else
-  fmtflags old_flags = os.setf(::std::ios::dec, ::std::ios::basefield);
-#endif
+  auto old_flags = os.setf(::std::ios::dec, ::std::ios::basefield);
 
   os << "width = " << length() << ::std::endl;
   os << "value = " << *this << ::std::endl;


### PR DESCRIPTION
This patch removes conditional type for os.setf(), which was failing on
msys2 llvm environment and replaces it by auto type.