### PR TITLE
Changed the sc_fifo to properly adjust with sc_bv

### DIFF
--- a/src/sysc/communication/sc_fifo.h
+++ b/src/sysc/communication/sc_fifo.h
@@ -398,7 +398,7 @@ sc_fifo<T>::buf_write( const T& val_ )
     if( m_free == 0 ) {
 	return false;
     }
-    m_buf[m_wi] = val_;
+    new (&m_buf[m_wi]) T(val_);
     m_wi = ( m_wi + 1 ) % m_size;
     m_free --;
     return true;
@@ -412,8 +412,8 @@ sc_fifo<T>::buf_read( T& val_ )
     if( m_free == m_size ) {
 	return false;
     }
-    val_ = m_buf[m_ri];
-    m_buf[m_ri] = T(); // clear entry for boost::shared_ptr, et al.
+    new (&val_) T(m_buf[m_ri]);
+    m_buf[m_ri].~T();
     m_ri = ( m_ri + 1 ) % m_size;
     m_free ++;
     return true;


### PR DESCRIPTION
This was brought up in #124, pretty much just implemented what was stated. Passed the tests, and attached is the result of the test code to duplicate the bug. Would love any direction if needed.
<img width="630" height="214" alt="Screenshot From 2025-10-15 15-45-47" src="https://github.com/user-attachments/assets/b1415271-86c0-4540-8527-84e11eb39d5d" />
