### PR TITLE
CI: Add msys2 UCRT64 and CLANGARM64 targets

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -87,3 +87,41 @@ jobs:
         cmake -B BUILD/RELEASE/BUILD .
         cmake --build BUILD/RELEASE/BUILD --config RELEASE --parallel
         cmake --install BUILD/RELEASE/BUILD --config RELEASE
+  msys2-ucrt64:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [gcc-shared, gcc-static]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: git mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja
+      - name: Build
+        run: |
+          SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh
+  msys2-clangarm64:
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [clang-shared, clang-static]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: git mingw-w64-clang-aarch64-clang  mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-ninja
+      - name: Build
+        run: |
+          SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -87,3 +87,41 @@ jobs:
         cmake -B BUILD/RELEASE/BUILD -DENABLE_REGRESSION=true .
         cmake --build BUILD/RELEASE/BUILD --config RELEASE --parallel
         cmake --install BUILD/RELEASE/BUILD --config RELEASE
+  msys2-ucrt64:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [gcc-shared-regression, gcc-static-regression]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: git mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja
+      - name: Build
+        run: |
+          SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh
+  msys2-clangarm64:
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [clang-shared-regression, clang-static-regression]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: git mingw-w64-clang-aarch64-clang  mingw-w64-clang-aarch64-cmake mingw-w64-clang-aarch64-ninja
+      - name: Build
+        run: |
+          SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,6 +30,12 @@ case "$SYSTEMC_CI_TARGET" in
     BUILD_SHARED_LIBRARY=true
     BUILD_REGRESSIONS=true
     ;;
+  gcc-static-regression)
+    CC=gcc
+    CXX=g++
+    BUILD_SHARED_LIBRARY=false
+    BUILD_REGRESSIONS=true
+    ;;
   clang-shared)
     CC=clang
     CXX=clang++
@@ -46,6 +52,12 @@ case "$SYSTEMC_CI_TARGET" in
     CC=clang
     CXX=clang++
     BUILD_SHARED_LIBRARY=true
+    BUILD_REGRESSIONS=true
+    ;;
+  clang-static-regression)
+    CC=clang
+    CXX=clang++
+    BUILD_SHARED_LIBRARY=false
     BUILD_REGRESSIONS=true
     ;;
   clang-shared-regression-asan)
@@ -75,16 +87,20 @@ case "$SYSTEMC_CI_TARGET" in
     ;;
 esac
 
-cd $SYSTEMC_SRC_PATH
-cmake -B BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD \
-      -DCMAKE_INSTALL_PREFIX=${SYSTEMC_SRC_PATH}/BUILD/${SYSTEMC_CI_TARGET} \
+
+cd "$SYSTEMC_SRC_PATH"
+cmake -B "BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD" \
+      -DCMAKE_INSTALL_PREFIX="${SYSTEMC_SRC_PATH}/BUILD/${SYSTEMC_CI_TARGET}" \
       -DCMAKE_CXX_FLAGS="$CXX_FLAGS" \
-      -DCMAKE_C_COMPILER=$CC \
-      -DCMAKE_CXX_COMPILER=$CXX \
-      -DENABLE_REGRESSION=$BUILD_REGRESSIONS \
-      -DBUILD_SHARED_LIBS=$BUILD_SHARED_LIBRARY .
-cmake --build BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/ --parallel
-cmake --install BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/
-make -j `getconf _NPROCESSORS_ONLN` -C BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/ check
+      -DCMAKE_C_COMPILER="$CC" \
+      -DCMAKE_CXX_COMPILER="$CXX" \
+      -DENABLE_REGRESSION="$BUILD_REGRESSIONS" \
+      -DBUILD_SHARED_LIBS="$BUILD_SHARED_LIBRARY" .
+cmake --build "BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/" --parallel
+cmake --install "BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/"
+
+if [[ "$BUILD_REGRESSIONS" == "true" ]]; then
+  cmake --build "BUILD/RELEASE-${SYSTEMC_CI_TARGET}/BUILD/" --parallel "$(getconf _NPROCESSORS_ONLN)" --target check
+fi
 
 exit 0


### PR DESCRIPTION
This commit adds two new platform for cmake and regressions tests
- MSYS2 clangarm64 (Windows on ARM64 runners)
- MSYS2 UCRT64 (Windows Latest runner)

On those platforms, systemc is built as a shared library.