### PR TITLE
Replace systemc.h with systemc header

### DIFF
--- a/examples/sysc/2.1/dpipe/main.cpp
+++ b/examples/sysc/2.1/dpipe/main.cpp
@@ -38,7 +38,11 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 
 // This program implements a delay pipe which passes values through a fifo
 // in a specified number of clocks. A value may be inserted at each clock

--- a/examples/sysc/2.1/forkjoin/forkjoin.cpp
+++ b/examples/sysc/2.1/forkjoin/forkjoin.cpp
@@ -37,7 +37,10 @@
  *****************************************************************************/
 
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 
 
 int test_function(double d)

--- a/examples/sysc/2.1/reset_signal_is/reset_signal_is.cpp
+++ b/examples/sysc/2.1/reset_signal_is/reset_signal_is.cpp
@@ -38,7 +38,10 @@
  *****************************************************************************/
 
 
-#include "systemc.h" 
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 SC_MODULE(CONSUMER)
 {
 	SC_CTOR(CONSUMER)

--- a/examples/sysc/2.1/sc_export/main.cpp
+++ b/examples/sysc/2.1/sc_export/main.cpp
@@ -68,7 +68,10 @@ bound to ports P1 and P2 of module X.
 
 */
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 
 // Interface
 class C_if : virtual public sc_interface

--- a/examples/sysc/2.1/sc_report/main.cpp
+++ b/examples/sysc/2.1/sc_report/main.cpp
@@ -40,7 +40,10 @@
 
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 
 
 /*

--- a/examples/sysc/2.1/scx_barrier/main.cpp
+++ b/examples/sysc/2.1/scx_barrier/main.cpp
@@ -39,7 +39,11 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::printf;
 #include "scx_barrier.h"
 using sc_core::scx_barrier;
 

--- a/examples/sysc/2.1/scx_mutex_w_policy/scx_mutex_w_policy.cpp
+++ b/examples/sysc/2.1/scx_mutex_w_policy/scx_mutex_w_policy.cpp
@@ -56,7 +56,12 @@
 // See section 7.4, page 120 of "System Design with SystemC" for
 //  additional discussion
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::rand;
+using std::remove;
 
 class scx_mutex_w_policy : public sc_mutex 
 { 

--- a/examples/sysc/2.3/sc_rvd/main.cpp
+++ b/examples/sysc/2.3/sc_rvd/main.cpp
@@ -37,7 +37,11 @@
 //  Andy Goodrich: new example using a ready-valid handshake for communication.
 //
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include <iomanip>
 #include "sc_rvd.h"
 

--- a/examples/sysc/2.3/sc_ttd/main.cpp
+++ b/examples/sysc/2.3/sc_ttd/main.cpp
@@ -37,7 +37,11 @@
 //  Andy Goodrich: new example using a toggle-toggle handshake for communication.
 //
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include <iomanip>
 #include "sc_ttd.h"
 

--- a/examples/sysc/2.3/simple_async/main.cpp
+++ b/examples/sysc/2.3/simple_async/main.cpp
@@ -28,7 +28,10 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 #include "async_event.h"
 
 #if SC_CPLUSPLUS >= 201103L

--- a/examples/sysc/2.4/in_class_initialization/adder.h
+++ b/examples/sysc/2.4/in_class_initialization/adder.h
@@ -30,7 +30,8 @@
 #ifndef ADDER_H_
 #define ADDER_H_
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
 
 template <typename T, int N_INPUTS>
 struct adder : sc_module {

--- a/examples/sysc/2.4/in_class_initialization/adder_int_5_pimpl.h
+++ b/examples/sysc/2.4/in_class_initialization/adder_int_5_pimpl.h
@@ -31,7 +31,8 @@
 #ifndef ADDER_PIMPL_H_
 #define ADDER_PIMPL_H_
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
 
 // Demonstrates how to remove compile dependency on adder.h header using PImpl
 class adder_int_5_pimpl {

--- a/examples/sysc/2.4/in_class_initialization/in_class_initialization.cpp
+++ b/examples/sysc/2.4/in_class_initialization/in_class_initialization.cpp
@@ -26,7 +26,9 @@
 
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
 
 #ifdef USE_PIMPL_ADDER
     #include "adder_int_5_pimpl.h"

--- a/examples/sysc/async_suspend/async_suspend.cpp
+++ b/examples/sysc/async_suspend/async_suspend.cpp
@@ -22,7 +22,11 @@
 
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::rand;
+using std::size_t;
+using std::srand;
 #include "node.h"
 #include <vector>
 

--- a/examples/sysc/async_suspend/collector.h
+++ b/examples/sysc/async_suspend/collector.h
@@ -31,6 +31,8 @@
 namespace plt = matplotlibcpp;
 #endif
 
+using std::cout;
+
 /* thread-safe collector to enable pretty-printing the output of the
  * simulation as a csv style output (import it into a spreadsheet and draw some
  * nice graphs !*/

--- a/examples/sysc/fft/fft_flpt/fft.cpp
+++ b/examples/sysc/fft/fft_flpt/fft.cpp
@@ -36,7 +36,11 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include "fft.h"
 
 void fft::entry()

--- a/examples/sysc/fft/fft_flpt/main.cpp
+++ b/examples/sysc/fft/fft_flpt/main.cpp
@@ -37,7 +37,10 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::fclose;
 #include "fft.h"
 #include "source.h"
 #include "sink.h"

--- a/examples/sysc/fft/fft_flpt/sink.cpp
+++ b/examples/sysc/fft/fft_flpt/sink.cpp
@@ -37,7 +37,12 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::fclose;
+using std::fopen;
+using std::fprintf;
 #include "sink.h"
 
 void sink::entry()

--- a/examples/sysc/fft/fft_flpt/source.cpp
+++ b/examples/sysc/fft/fft_flpt/source.cpp
@@ -37,7 +37,13 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
 #include "source.h"
 void source::entry()
 { FILE *fp_real, *fp_imag;

--- a/examples/sysc/fft/fft_fxpt/fft.cpp
+++ b/examples/sysc/fft/fft_fxpt/fft.cpp
@@ -37,7 +37,11 @@
 
 
 /* This is the implementation file for the synchronous process "fft" */
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include "fft.h"
 
 

--- a/examples/sysc/fft/fft_fxpt/main.cpp
+++ b/examples/sysc/fft/fft_fxpt/main.cpp
@@ -37,7 +37,11 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::FILE;
+using std::fclose;
 #include "fft.h"
 #include "source.h"
 #include "sink.h"

--- a/examples/sysc/fft/fft_fxpt/sink.cpp
+++ b/examples/sysc/fft/fft_fxpt/sink.cpp
@@ -37,7 +37,13 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::FILE;
+using std::fclose;
+using std::fopen;
+using std::fprintf;
 #include "sink.h"
 
 void sink::entry()

--- a/examples/sysc/fft/fft_fxpt/source.cpp
+++ b/examples/sysc/fft/fft_fxpt/source.cpp
@@ -37,7 +37,14 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
 #include "source.h"
 
 void source::entry()

--- a/examples/sysc/fir/display.cpp
+++ b/examples/sysc/fir/display.cpp
@@ -35,7 +35,10 @@
  
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
 #include "display.h"
 
 void display::entry(){

--- a/examples/sysc/fir/fir.cpp
+++ b/examples/sysc/fir/fir.cpp
@@ -35,7 +35,9 @@
     
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
 #include "fir.h"
 
 void fir::entry() {

--- a/examples/sysc/fir/fir_data.cpp
+++ b/examples/sysc/fir/fir_data.cpp
@@ -35,7 +35,11 @@
     
  *****************************************************************************/
  
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include "fir_data.h"
 
 void fir_data::entry()

--- a/examples/sysc/fir/fir_fsm.cpp
+++ b/examples/sysc/fir/fir_fsm.cpp
@@ -35,7 +35,11 @@
     
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include "fir_fsm.h"
 
 void fir_fsm::entry() {

--- a/examples/sysc/fir/fir_top.h
+++ b/examples/sysc/fir/fir_top.h
@@ -35,7 +35,9 @@
     
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
 #include "fir_fsm.h"
 #include "fir_data.h"
 

--- a/examples/sysc/fir/main.cpp
+++ b/examples/sysc/fir/main.cpp
@@ -35,7 +35,9 @@
     
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
 #include "stimulus.h"
 #include "display.h"
 #include "fir.h"

--- a/examples/sysc/fir/main_rtl.cpp
+++ b/examples/sysc/fir/main_rtl.cpp
@@ -35,7 +35,9 @@
     
  *****************************************************************************/
  
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
 #include "stimulus.h"
 #include "display.h"
 #include "fir_top.h"

--- a/examples/sysc/fir/stimulus.cpp
+++ b/examples/sysc/fir/stimulus.cpp
@@ -35,7 +35,11 @@
     
  *****************************************************************************/
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
 #include "stimulus.h"
 
 void stimulus::entry() {

--- a/examples/sysc/pipe/display.cpp
+++ b/examples/sysc/pipe/display.cpp
@@ -35,7 +35,9 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::printf;
 #include "display.h"
 
 #include <stdio.h>

--- a/examples/sysc/pipe/main.cpp
+++ b/examples/sysc/pipe/main.cpp
@@ -36,7 +36,8 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "stage1.h"
 #include "stage2.h"
 #include "stage3.h"

--- a/examples/sysc/pipe/numgen.cpp
+++ b/examples/sysc/pipe/numgen.cpp
@@ -35,7 +35,8 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "numgen.h"
 
 // definition of the `generate' method

--- a/examples/sysc/pipe/stage1.cpp
+++ b/examples/sysc/pipe/stage1.cpp
@@ -35,7 +35,8 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "stage1.h"
 
 //Definition of addsub method

--- a/examples/sysc/pipe/stage2.cpp
+++ b/examples/sysc/pipe/stage2.cpp
@@ -35,7 +35,8 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "stage2.h"
 
 //definition of multdiv method

--- a/examples/sysc/pipe/stage3.cpp
+++ b/examples/sysc/pipe/stage3.cpp
@@ -35,7 +35,8 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "stage3.h"
 
 //Definition of power method

--- a/examples/sysc/pkt_switch/fifo.h
+++ b/examples/sysc/pkt_switch/fifo.h
@@ -38,7 +38,10 @@
 #ifndef FIFO_H_INCLUDED
 #define FIFO_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 #include "pkt.h"
 
 struct fifo {

--- a/examples/sysc/pkt_switch/main.cpp
+++ b/examples/sysc/pkt_switch/main.cpp
@@ -36,7 +36,10 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 #include "pkt.h"
 #include "switch_clk.h"
 #include "sender.h"

--- a/examples/sysc/pkt_switch/pkt.h
+++ b/examples/sysc/pkt_switch/pkt.h
@@ -37,7 +37,10 @@
 #ifndef PKT_H_INCLUDED
 #define PKT_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 
 struct pkt {
        sc_int<8> data;

--- a/examples/sysc/pkt_switch/receiver.cpp
+++ b/examples/sysc/pkt_switch/receiver.cpp
@@ -37,6 +37,8 @@
  *****************************************************************************/
 
 #include "receiver.h"
+using std::cout;
+using std::endl;
 
 
 void receiver:: entry()

--- a/examples/sysc/pkt_switch/receiver.h
+++ b/examples/sysc/pkt_switch/receiver.h
@@ -39,7 +39,10 @@
 #ifndef RECEIVER_H_INCLUDED
 #define RECEIVER_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 #include "pkt.h"
 
 struct receiver: sc_module {

--- a/examples/sysc/pkt_switch/sender.cpp
+++ b/examples/sysc/pkt_switch/sender.cpp
@@ -40,6 +40,8 @@
 #include <stdlib.h>
 #include <time.h>
 #include "sender.h"
+using std::cout;
+using std::endl;
 
 void sender:: entry()
 {

--- a/examples/sysc/pkt_switch/sender.h
+++ b/examples/sysc/pkt_switch/sender.h
@@ -38,7 +38,10 @@
 #ifndef SENDER_H_INCLUDED
 #define SENDER_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 #include "pkt.h"
 
 struct sender: sc_module {

--- a/examples/sysc/pkt_switch/switch.cpp
+++ b/examples/sysc/pkt_switch/switch.cpp
@@ -36,7 +36,13 @@
 
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::cout;
+using std::endl;
+using std::free;
+using std::ostream;
 #include "pkt.h"
 #include "switch.h"
 #include "fifo.h"

--- a/examples/sysc/pkt_switch/switch.h
+++ b/examples/sysc/pkt_switch/switch.h
@@ -38,7 +38,10 @@
 #ifndef SWITCH_H_INCLUDED
 #define SWITCH_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::ostream;
 #include "pkt.h"
 
 struct mcast_pkt_switch : sc_module {

--- a/examples/sysc/pkt_switch/switch_clk.h
+++ b/examples/sysc/pkt_switch/switch_clk.h
@@ -39,7 +39,8 @@
 #ifndef SWITCH_CLK_H_INCLUDED
 #define SWITCH_CLK_H_INCLUDED
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 
 struct switch_clk: sc_module {
       sc_out<bool>   switch_cntrl;

--- a/examples/sysc/risc_cpu/bios.cpp
+++ b/examples/sysc/risc_cpu/bios.cpp
@@ -36,7 +36,15 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
+using std::ios;
+using std::printf;
 #include "bios.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/dcache.cpp
+++ b/examples/sysc/risc_cpu/dcache.cpp
@@ -36,7 +36,14 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
+using std::printf;
 #include "dcache.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/decode.cpp
+++ b/examples/sysc/risc_cpu/decode.cpp
@@ -37,7 +37,12 @@
  
 
 #include <climits>	// for definition on value 's MAX
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::ios;
+using std::printf;
 #include "decode.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/exec.cpp
+++ b/examples/sysc/risc_cpu/exec.cpp
@@ -36,7 +36,11 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::printf;
 #include "exec.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/fetch.cpp
+++ b/examples/sysc/risc_cpu/fetch.cpp
@@ -36,7 +36,12 @@
  *****************************************************************************/
  
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::ios;
+using std::printf;
 #include "fetch.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/floating.cpp
+++ b/examples/sysc/risc_cpu/floating.cpp
@@ -36,7 +36,11 @@
  *****************************************************************************/
  
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::printf;
 #include "floating.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/icache.cpp
+++ b/examples/sysc/risc_cpu/icache.cpp
@@ -39,7 +39,15 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
+using std::ios;
+using std::printf;
 #include "icache.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/main.cpp
+++ b/examples/sysc/risc_cpu/main.cpp
@@ -40,7 +40,14 @@
 
 
 #include "directive.h"
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
+using std::cout;
+using std::endl;
+using std::fopen;
+using std::fscanf;
+using std::printf;
 #include "bios.h"
 #include "paging.h"
 #include "icache.h"

--- a/examples/sysc/risc_cpu/mmxu.cpp
+++ b/examples/sysc/risc_cpu/mmxu.cpp
@@ -36,7 +36,12 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::ios;
+using std::printf;
 #include "mmxu.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/paging.cpp
+++ b/examples/sysc/risc_cpu/paging.cpp
@@ -36,7 +36,11 @@
  *****************************************************************************/
  
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::printf;
 #include "paging.h"
 #include "directive.h"
 

--- a/examples/sysc/risc_cpu/pic.cpp
+++ b/examples/sysc/risc_cpu/pic.cpp
@@ -36,7 +36,8 @@
  *****************************************************************************/
 
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "pic.h"
 
 void pic::entry(){

--- a/examples/sysc/rsa/rsa.cpp
+++ b/examples/sysc/rsa/rsa.cpp
@@ -66,7 +66,15 @@
 #include <sys/types.h>
 #include <time.h>
 #include <stdlib.h>    // drand48, srand48
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
+using namespace sc_dt;
+using std::atoi;
+using std::cout;
+using std::endl;
+using std::rand;
+using std::size_t;
+using std::srand;
 
 #define DEBUG_SYSTEMC // #undef this to disable assertions.
 

--- a/examples/sysc/simple_bus/simple_bus.h
+++ b/examples/sysc/simple_bus/simple_bus.h
@@ -44,7 +44,9 @@
 #ifndef __simple_bus_h
 #define __simple_bus_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_request.h"

--- a/examples/sysc/simple_bus/simple_bus_arbiter.h
+++ b/examples/sysc/simple_bus/simple_bus_arbiter.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_arbiter_h
 #define __simple_bus_arbiter_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_request.h"

--- a/examples/sysc/simple_bus/simple_bus_arbiter_if.h
+++ b/examples/sysc/simple_bus/simple_bus_arbiter_if.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_arbiter_if_h
 #define __simple_bus_arbiter_if_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 

--- a/examples/sysc/simple_bus/simple_bus_blocking_if.h
+++ b/examples/sysc/simple_bus/simple_bus_blocking_if.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_blocking_if_h
 #define __simple_bus_blocking_if_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 

--- a/examples/sysc/simple_bus/simple_bus_direct_if.h
+++ b/examples/sysc/simple_bus/simple_bus_direct_if.h
@@ -38,7 +38,8 @@
 #ifndef __simple_bus_direct_if_h
 #define __simple_bus_direct_if_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
 
 class simple_bus_direct_if
   : public virtual sc_interface

--- a/examples/sysc/simple_bus/simple_bus_fast_mem.h
+++ b/examples/sysc/simple_bus/simple_bus_fast_mem.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_fast_mem_h
 #define __simple_bus_fast_mem_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_slave_if.h"

--- a/examples/sysc/simple_bus/simple_bus_main.cpp
+++ b/examples/sysc/simple_bus/simple_bus_main.cpp
@@ -35,7 +35,8 @@
  
  *****************************************************************************/
 
-#include "systemc.h"
+#include <systemc>
+using namespace sc_core;
 #include "simple_bus_test.h"
 
 int sc_main(int, char **)

--- a/examples/sysc/simple_bus/simple_bus_master_blocking.h
+++ b/examples/sysc/simple_bus/simple_bus_master_blocking.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_master_blocking_h
 #define __simple_bus_master_blocking_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_blocking_if.h"

--- a/examples/sysc/simple_bus/simple_bus_master_direct.h
+++ b/examples/sysc/simple_bus/simple_bus_master_direct.h
@@ -39,7 +39,8 @@
 #ifndef __simple_bus_master_direct_h
 #define __simple_bus_master_direct_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
 
 #include "simple_bus_direct_if.h"
 

--- a/examples/sysc/simple_bus/simple_bus_master_non_blocking.h
+++ b/examples/sysc/simple_bus/simple_bus_master_non_blocking.h
@@ -39,7 +39,9 @@
 #ifndef __simple_bus_master_non_blocking_h
 #define __simple_bus_master_non_blocking_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_non_blocking_if.h"

--- a/examples/sysc/simple_bus/simple_bus_non_blocking_if.h
+++ b/examples/sysc/simple_bus/simple_bus_non_blocking_if.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_non_blocking_if_h
 #define __simple_bus_non_blocking_if_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 

--- a/examples/sysc/simple_bus/simple_bus_slave_if.h
+++ b/examples/sysc/simple_bus/simple_bus_slave_if.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_slave_if_h
 #define __simple_bus_slave_if_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_direct_if.h"

--- a/examples/sysc/simple_bus/simple_bus_slow_mem.h
+++ b/examples/sysc/simple_bus/simple_bus_slow_mem.h
@@ -38,7 +38,9 @@
 #ifndef __simple_bus_slow_mem_h
 #define __simple_bus_slow_mem_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 #include "simple_bus_types.h"
 #include "simple_bus_slave_if.h"

--- a/examples/sysc/simple_bus/simple_bus_test.h
+++ b/examples/sysc/simple_bus/simple_bus_test.h
@@ -38,7 +38,8 @@
 #ifndef __simple_bus_test_h
 #define __simple_bus_test_h
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
 
 #include "simple_bus_master_blocking.h"
 #include "simple_bus_master_non_blocking.h"

--- a/examples/sysc/simple_bus/simple_bus_types.h
+++ b/examples/sysc/simple_bus/simple_bus_types.h
@@ -39,7 +39,9 @@
 #define __simple_bus_types_h
 
 #include <stdio.h>
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::FILE;
 
 enum simple_bus_status { SIMPLE_BUS_OK = 0
 			 , SIMPLE_BUS_REQUEST

--- a/examples/sysc/simple_fifo/simple_fifo.cpp
+++ b/examples/sysc/simple_fifo/simple_fifo.cpp
@@ -40,7 +40,11 @@
  *****************************************************************************/
 
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::cout;
+using std::endl;
+using std::flush;
 
 class write_if : virtual public sc_interface
 {

--- a/examples/sysc/simple_perf/simple_perf.cpp
+++ b/examples/sysc/simple_perf/simple_perf.cpp
@@ -84,7 +84,12 @@
  *****************************************************************************/
 
 
-#include <systemc.h>
+#include <systemc>
+using namespace sc_core;
+using std::atoi;
+using std::cout;
+using std::endl;
+using std::rand;
 
 class write_if : virtual public sc_interface
 {


### PR DESCRIPTION
Minimal change replacing systemc.h with systemc in examples, following 5.1.2 recommendation that applications should prefer systemc over systemc.h.

https://github.com/accellera-official/systemc/issues/134