### PR TITLE
Fix to sc_log vector push, enable c++17 support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,14 +46,30 @@ cmake_minimum_required(VERSION 3.16...3.31)
 
 option(SYSTEMC_UNITY_BUILD "Enable unity build" OFF)
 
+# Detect format string support: prefer std::format (C++20), fall back to fmt.
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS "")
+set(CMAKE_CXX_STANDARD 20)
+check_cxx_source_compiles("
+    #include <format>
+    int main() { auto s = std::format(\"{}\", 42); return 0; }
+" HAS_STD_FORMAT)
+unset(CMAKE_CXX_STANDARD)
+
+if(NOT HAS_STD_FORMAT)
+    find_package(fmt QUIET)
+endif()
+
 function(add_systemc_library libName scBuildDefine)
 
     add_library(${libName} ${ARGN})
 
-    target_compile_features(
-        ${libName}
-        PUBLIC
-        cxx_std_20)
+    target_compile_features(${libName} PUBLIC cxx_std_20)
+
+    if(NOT HAS_STD_FORMAT AND fmt_FOUND)
+        target_link_libraries(${libName} PUBLIC fmt::fmt)
+        target_compile_definitions(${libName} PUBLIC FMT_SHARED)
+    endif()
 
     target_compile_definitions (
         ${libName}

--- a/src/sysc/log/sc_log.cpp
+++ b/src/sysc/log/sc_log.cpp
@@ -39,8 +39,14 @@ const std::map<sc_log_level, std::string> log_level_map = {
     {sc_log_level::TRACE, "TRACE"}
 };
 
+static thread_local sc_log_logger_cache* s_current = nullptr;
+
+sc_log_logger_cache* sc_log_logger_cache::get_current() { return s_current; }
+void sc_log_logger_cache::set_current(sc_log_logger_cache* p) { s_current = p; }
+
 sc_log_level sc_log_logger_cache::get_log_verbosity_cached(
     const char *file, int line, std::string_view local_tag) {
+  s_current = this;
   if (level != sc_log_level::UNSET) {
     return level;
   }
@@ -48,14 +54,18 @@ sc_log_level sc_log_logger_cache::get_log_verbosity_cached(
   return sc_log_impl::sc_get_log_verbosity(*this, file, line, local_tag);
 }
 
+void sc_log_logger_cache::set_tag(std::string new_tag) {
+  tag = std::move(new_tag);
+  level = sc_log_level::UNSET;
+}
+
 } // namespace sc_core
 
 // Global default logger with empty tag (in global namespace for proper name
 // shadowing). This logger is used when no specific logger handle is provided.
-// Note: Using string_view{} for empty views and nullptr for typename_str.
 sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE{
     sc_core::sc_log_level::UNSET,  // level
-    std::string_view{},             // tag (empty)
-    std::string_view{},             // scname (empty)
+    {},                             // tag (empty)
+    {},                             // scname (empty)
     nullptr                         // typename_str (no type info)
 };

--- a/src/sysc/log/sc_log.h
+++ b/src/sysc/log/sc_log.h
@@ -71,7 +71,14 @@ extern sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE;
 // macro When used without parentheses, it's the empty string; with parentheses,
 // it calls std::format
 static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
+#if __has_include(<fmt/format.h>)
+#include <fmt/format.h>
+#define SC_LOG_PRIV__FMT_EMPTY_STR(...) fmt::format(__VA_ARGS__)
+#elif defined(__cpp_lib_format)
 #define SC_LOG_PRIV__FMT_EMPTY_STR(...) std::format(__VA_ARGS__)
+#else
+#define SC_LOG_PRIV__FMT_EMPTY_STR(...) ""
+#endif
 
 // Internal verbosity check variants (used by public SC_LOG_AT macro)
 #define SC_LOG_PRIV__VBSTY_CHECK0(lvl)                                         \
@@ -85,7 +92,7 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
       return ((x.level >= (lvl)) &&                                            \
               (x.get_log_verbosity_cached(__FILE__, __LINE__) >= (lvl)));      \
     } else {                                                                   \
-      return SC_LOG_PRIV__VBSTY_CHECK2(lvl, SC_LOG_LOG_LEVEL_CACHE, x);        \
+      return SC_LOG_PRIV__VBSTY_CHECK2(lvl, SC_LOG_LOG_LEVEL_CACHE_GLOBAL, x);  \
     }                                                                          \
   }(arg1))
 
@@ -98,13 +105,13 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
 
 // Internal tag extraction variants (used by public SC_LOG_MSG macro)
 #define SC_LOG_PRIV__GET_TAG0()                                                \
-  (SC_LOG_LOG_LEVEL_CACHE.tag.empty() ? SC_LOG_LOG_LEVEL_CACHE.scname.data()   \
-                                      : SC_LOG_LOG_LEVEL_CACHE.tag.data())
+  (SC_LOG_LOG_LEVEL_CACHE.tag.empty() ? SC_LOG_LOG_LEVEL_CACHE.scname.c_str()  \
+                                      : SC_LOG_LOG_LEVEL_CACHE.tag.c_str())
 
 #define SC_LOG_PRIV__GET_TAG1(arg1)                                            \
   ([&](auto &&x) -> const char * {                                             \
     if constexpr (SC_LOG_PRIV__IS_LOGGER_HANDLE(x)) {                          \
-      return (x.tag.empty() ? x.scname.data() : x.tag.data());                 \
+      return (x.tag.empty() ? x.scname.c_str() : x.tag.c_str());              \
     } else {                                                                   \
       return x;                                                                \
     }                                                                          \
@@ -184,7 +191,8 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
  */
 #define SC_LOG_HANDLE_VECTOR_PUSH_BACK(NAME, tag_str)                          \
   SC_LOG_PRIV__HANDLE_NAME(NAME).push_back(                                    \
-      {sc_core::sc_log_level::UNSET, "", tag_str})
+      sc_core::sc_log_handle_factory::make(                                    \
+          sc_core::sc_log_level::UNSET, tag_str, this))
 
 /**
  * SC_LOG_AT - Log a message at a specific level

--- a/src/sysc/log/sc_log.h
+++ b/src/sysc/log/sc_log.h
@@ -27,7 +27,11 @@
 
 #include <array>
 #include <cstring>
+#if __has_include(<format>)
 #include <format>
+#elif __has_include(<fmt/format.h>)
+#include <fmt/format.h>
+#endif
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -68,14 +72,13 @@ extern sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE;
   std::is_same_v<std::decay_t<decltype(x)>, sc_core::sc_log_logger_cache>
 
 // Note: SC_LOG_PRIV__FMT_EMPTY_STR is both a const char* and a function-like
-// macro When used without parentheses, it's the empty string; with parentheses,
-// it calls std::format
+// macro. Without parentheses it's the empty string; with parentheses it calls
+// std::format (C++20, preferred) or fmt::format (fallback).
 static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
-#if __has_include(<fmt/format.h>)
-#include <fmt/format.h>
-#define SC_LOG_PRIV__FMT_EMPTY_STR(...) fmt::format(__VA_ARGS__)
-#elif defined(__cpp_lib_format)
+#if defined(__cpp_lib_format)
 #define SC_LOG_PRIV__FMT_EMPTY_STR(...) std::format(__VA_ARGS__)
+#elif defined(FMT_VERSION)
+#define SC_LOG_PRIV__FMT_EMPTY_STR(...) fmt::format(__VA_ARGS__)
 #else
 #define SC_LOG_PRIV__FMT_EMPTY_STR(...) ""
 #endif

--- a/src/sysc/log/sc_log_types.h
+++ b/src/sysc/log/sc_log_types.h
@@ -166,8 +166,8 @@ struct sc_log_impl;
  */
 struct sc_log_logger_cache {
   sc_log_level level = sc_log_level::UNSET;
-  std::string_view tag{};      // Logger tag/identifier
-  std::string_view scname{};   // Captured sc_object name (from this->name())
+  std::string tag{};           // Logger tag/identifier (owns the string)
+  std::string scname{};        // Captured sc_object name (owns the string)
   const char* typename_str = nullptr; // Captured type name (from typeid(*this).name())
 
   /**
@@ -183,6 +183,27 @@ struct sc_log_logger_cache {
    */
   sc_log_level get_log_verbosity_cached(const char *file, int line,
                                         std::string_view local_tag = {});
+
+  /**
+   * @brief Set the tag to a runtime-computed string.
+   *
+   * The cached level is reset so the verbosity function re-evaluates
+   * with the new tag on the next log statement.
+   *
+   * @param new_tag the new tag string
+   */
+  void set_tag(std::string new_tag);
+
+  /// Get/set the logger cache that most recently performed a verbosity
+  /// check on this thread.  Used by the report handler to access
+  /// scname/tag/typename.
+  ///
+  /// Lifecycle: set by get_log_verbosity_cached() (called during the
+  /// SC_LOG verbosity check), cleared by ~sc_logger() (after the report
+  /// handler has run).  Accessor functions ensure correct linkage across
+  /// shared library boundaries.
+  static sc_log_logger_cache* get_current();
+  static void set_current(sc_log_logger_cache* p);
 };
 
 /**
@@ -193,8 +214,6 @@ struct sc_log_logger_cache {
  * default constructor, so the owning object pointer must be provided here (when
  * available).
  *
- * The factory returns string_view for tag and scname (which reference string
- * literals or existing strings), and const char* for typename_str (from typeid).
  */
 struct sc_log_handle_factory {
   template <class TYPE>
@@ -204,8 +223,8 @@ struct sc_log_handle_factory {
     const char *t = typeid(*p).name();
     return sc_log_logger_cache{
         lvl,
-        tag_str ? std::string_view(tag_str) : std::string_view(),
-        n ? std::string_view(n) : std::string_view(),
+        tag_str ? std::string(tag_str) : std::string(),
+        n ? std::string(n) : std::string(),
         t  // typeid().name() returns const char* with static storage
     };
   }
@@ -214,8 +233,8 @@ struct sc_log_handle_factory {
                                          const char *tag_str) {
     return sc_log_logger_cache{
         lvl,
-        tag_str ? std::string_view(tag_str) : std::string_view(),
-        std::string_view(),
+        tag_str ? std::string(tag_str) : std::string(),
+        std::string(),
         nullptr  // No type information for static loggers
     };
   }
@@ -250,6 +269,7 @@ struct sc_logger {
             sc_log_level verbosity = sc_core::sc_log_level::INFO)
       : t(nullptr), file(file), line(line), level(verbosity) {}
 
+
   sc_logger() = delete;
 
   sc_logger(const sc_logger &) = delete;
@@ -275,9 +295,10 @@ struct sc_logger {
                             sc_core::SC_STOP | sc_core::SC_ABORT));
     }
     ::sc_core::sc_report_handler::report(
-        SEVERITY, t ? t : "SystemC", os.str().c_str(),
+        SEVERITY, (t && *t) ? t : "SystemC", os.str().c_str(),
         static_cast<sc_core::sc_verbosity>(level), file, line);
     sc_core::sc_report_handler::set_actions(SEVERITY, old);
+    sc_log_logger_cache::set_current(nullptr);
   }
   /**
    * @fn sc_logger& type()
@@ -336,6 +357,7 @@ protected:
 // underscores are generally reserved, this pattern (_m_*) is safe as it doesn't
 // conflict with reserved patterns (__* or _Capital*).
 #define SC_LOG_LOG_LEVEL_CACHE _m_sc_log_log_level_cache_
+#define SC_LOG_LOG_LEVEL_CACHE_GLOBAL ::_m_sc_log_log_level_cache_
 
 /** @} */ // end of sc_log
 #endif    /* _SC_LOG_TYPES_H_ */

--- a/src/sysc/log/sc_log_types.h
+++ b/src/sysc/log/sc_log_types.h
@@ -26,9 +26,12 @@
 #include <array>
 #include <climits>
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <typeinfo>
 #include <vector>
 


### PR DESCRIPTION

1/ with a very few lines of code, we can allow people to use C++17 (with the fmt library installed) - this would mean that people on old ubuntu’s (2022 for instance, not _that_ old) would have a path to use it, and the cost to us is really not that much…. Feels like we should do that?

2/ There’s a minor bug that puts the tag/name in the wrong place for a vector, trivial fix.

3/ There is currently no easy way for the current implementation to access its data from the back-end report handler. This is just “inconvenient” and limits what you can choose to print out. The change is fairly trivial and will make things a little more flexible - it’s not a change to the standard, just the implementation.



Actually, there is more to it :-( a few more bug fixes, but also we need a new API see below :

Bug fixes:
- Prefer fmt::format over std::format when fmt is available, fixing
  incompatibility with fmt types (e.g. fmt::join) on C++20
- Use SC_LOG_LOG_LEVEL_CACHE_GLOBAL in VBSTY_CHECK1 else branch to
  fix "invalid use of non-static data member" in nested classes
- Fix VECTOR_PUSH_BACK field mapping bug (tag_str was placed in scname)
- Fix empty string fallback in sc_logger: (t && *t) ? t : "SystemC"

Ownership and types:
- Change tag and scname from string_view to std::string for clear
  ownership semantics, enabling runtime tag changes without external
  lifetime management. SSO avoids heap allocation for typical tags.

New API:
- sc_log_logger_cache::set_tag(std::string) — change tag at runtime,
  resets cached level for re-evaluation
- SC_LOG_HANDLE_RESET macro (0/1/2 arg variants) — reset cached level
  and optionally change tag on existing handles
- sc_log_logger_cache::get_current()/set_current() — thread-safe
  accessor for current logger pointer across shared library boundaries.
  Set by get_log_verbosity_cached(), cleared by ~sc_logger().
