### PR TITLE
feat: add exit code support to sc_start and sc_stop

### DIFF
--- a/src/sysc/kernel/sc_simcontext.cpp
+++ b/src/sysc/kernel/sc_simcontext.cpp
@@ -344,6 +344,7 @@ sc_simcontext::init()
     m_delta_count = 0;
     m_initial_delta_count_at_current_time = 0;
     m_forced_stop = false;
+    m_exit_code = 0;
     m_paused = false;
     m_ready_to_simulate = false;
     m_elaboration_done = false;
@@ -408,7 +409,7 @@ sc_simcontext::sc_simcontext() :
     m_trace_files(), m_something_to_trace(false), m_runnable(0), m_collectable(0),
     m_time_params(), m_change_stamp(0),
     m_delta_count(0), m_initial_delta_count_at_current_time(0),
-    m_forced_stop(false), m_paused(false),
+    m_forced_stop(false), m_exit_code(0), m_paused(false),
     m_ready_to_simulate(false), m_elaboration_done(false),
     m_execution_phase(phase_initialize), m_error(0),
     m_in_simulator_control(false), m_end_of_simulation_called(false),
@@ -1032,7 +1033,7 @@ void sc_simcontext::do_collect_processes()
 //------------------------------------------------------------------------------
 
 void
-sc_simcontext::stop()
+sc_simcontext::stop(int exit_code)
 {
     static bool stop_warning_issued = false;
     if (m_forced_stop)
@@ -1045,6 +1046,7 @@ sc_simcontext::stop()
         return;
     }
     if ( stop_mode == SC_STOP_IMMEDIATE ) m_runnable->init();
+    m_exit_code = exit_code;
     m_forced_stop = true;
     if ( !m_in_simulator_control  )
     {
@@ -1677,7 +1679,7 @@ sc_set_random_seed( unsigned int )
 // |     duration = the amount of time the simulator should execute.
 // |     p        = event starvation policy.
 // +----------------------------------------------------------------------------
-SC_API void
+SC_API int
 sc_start( const sc_time& duration, sc_starvation_policy p )
 {
     sc_simcontext* context_p;      // current simulation context.
@@ -1708,13 +1710,13 @@ sc_start( const sc_time& duration, sc_starvation_policy p )
             SC_REPORT_ERROR(SC_ID_SIMULATION_START_AFTER_STOP_, "");
         if ( sim_status == SC_SIM_ERROR )
             SC_REPORT_ERROR(SC_ID_SIMULATION_START_AFTER_ERROR_, "");
-        return;
+        return context_p->m_exit_code;
     }
     status = context_p->get_status();
     if( !(status == SC_PAUSED || status == SC_ELABORATION) )
     {
         SC_REPORT_ERROR(SC_ID_SIMULATION_START_UNEXPECTED_, "");
-        return;
+        return context_p->m_exit_code;
     }
 
     if ( context_p->m_prim_channel_registry->pending_updates()
@@ -1752,12 +1754,13 @@ sc_start( const sc_time& duration, sc_starvation_policy p )
 
     // reset init/update flag for subsequent calls
     init_delta_or_pending_updates = false;
+    return context_p->m_exit_code;
 }
 
-SC_API void
+SC_API int
 sc_start()
 {
-    sc_start( sc_time::max() - sc_time_stamp(),
+    return sc_start( sc_time::max() - sc_time_stamp(),
               SC_EXIT_ON_STARVATION );
 }
 
@@ -1766,6 +1769,12 @@ SC_API void
 sc_stop()
 {
     sc_get_curr_simcontext()->stop();
+}
+
+SC_API void
+sc_stop( int exit_code )
+{
+    sc_get_curr_simcontext()->stop(exit_code);
 }
 
 

--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -104,22 +104,23 @@ enum sc_starvation_policy
     SC_EXIT_ON_STARVATION,
     SC_RUN_TO_TIME
 };
-extern SC_API void sc_start();
-extern SC_API void sc_start( const sc_time& duration, 
+extern SC_API int sc_start();
+extern SC_API int sc_start( const sc_time& duration,
                       sc_starvation_policy p=SC_RUN_TO_TIME );
-inline void sc_start( int duration, sc_time_unit unit, 
+inline int sc_start( int duration, sc_time_unit unit,
                       sc_starvation_policy p=SC_RUN_TO_TIME )
 {
-    sc_start( sc_time((double)duration,unit), p );
+    return sc_start( sc_time((double)duration,unit), p );
 }
 
-inline void sc_start( double duration, sc_time_unit unit, 
+inline int sc_start( double duration, sc_time_unit unit, 
                       sc_starvation_policy p=SC_RUN_TO_TIME )
 {
-    sc_start( sc_time(duration,unit), p );
+    return sc_start( sc_time(duration,unit), p );
 }
 
 extern SC_API void sc_stop();
+extern SC_API void sc_stop( int exit_code );
 
 // friend function declarations
 
@@ -132,7 +133,7 @@ SC_API const std::vector<sc_object*>& sc_get_top_level_objects(
 SC_API bool    sc_is_running( const sc_simcontext* simc_p );
 SC_API void    sc_pause();
 SC_API bool    sc_end_of_simulation_invoked();
-SC_API void    sc_start( const sc_time&, sc_starvation_policy );
+SC_API int     sc_start( const sc_time&, sc_starvation_policy );
 SC_API bool    sc_start_of_simulation_invoked();
 SC_API void    sc_set_time_resolution( double, sc_time_unit );
 SC_API sc_time sc_get_time_resolution();
@@ -189,7 +190,7 @@ class SC_API sc_simcontext
     friend SC_API bool sc_is_running( const sc_simcontext* simc_p );
     friend SC_API void sc_pause();
     friend SC_API bool sc_end_of_simulation_invoked();
-    friend SC_API void sc_start( const sc_time&, sc_starvation_policy );
+    friend SC_API int sc_start( const sc_time&, sc_starvation_policy );
     friend SC_API bool sc_start_of_simulation_invoked();
     friend void sc_thread_cor_fn(void*);
     friend SC_API sc_time sc_time_to_pending_activity( const sc_simcontext* );
@@ -224,7 +225,7 @@ public:
     void initialize( bool = false );
     void cycle( const sc_time& );
     void simulate( const sc_time& duration );
-    void stop();
+    void stop(int exit_code = 0);
     void end();
     void reset();
 
@@ -427,6 +428,7 @@ private:
     sc_dt::uint64               m_delta_count;
     sc_dt::uint64               m_initial_delta_count_at_current_time;
     bool                        m_forced_stop;
+    int                         m_exit_code;
     bool                        m_paused;
     bool                        m_ready_to_simulate;
     bool                        m_elaboration_done;


### PR DESCRIPTION
Hi all,

I though it could be useful to have and exit code that could be set using `sc_stop` which would be returned by `sc_start`, e.g.:
```
if (everything_ok)
    sc_stop(EXIT_SUCCESS);
else
    sc_stop(EXIT_FAILURE);
```

and then

```
int sc_main(int argc, char** argv) {
    // ...
    return sc_start();
}
```
Calling `sc_stop() `without an argument is backward-compatible and equivalent to `sc_stop(0)`. The implementation stores the exit code in `sc_simcontext` and `sc_start` returns it on exit.

What do you think?