### PR TITLE
tests: fix memory leaks

### DIFF
--- a/examples/sysc/async_suspend/node.h
+++ b/examples/sysc/async_suspend/node.h
@@ -118,6 +118,7 @@ public:
         init_socket("output"),
         target_socket("input"),
         txnSent_c(0),
+        txn(nullptr),
         suspendReq(false),
         col(c),
         running(true),
@@ -136,12 +137,22 @@ public:
         sensitive << txnSentEvent;
     }
 
-    ~asynctestnode()
+    virtual ~asynctestnode()
     {
         running = false;
         while (!finished)
             txnSentMethod();
         if (m_thread.joinable()) m_thread.join();
+
+        delete txn;
+        txn = nullptr;
+
+        while (!queue.empty())
+        {
+            delete queue.front();
+            queue.pop();
+        }
+
     }
 
     // This will cause SystemC time to be driven forwards. But, if we're not
@@ -239,6 +250,7 @@ public:
 
                 // Send transaction to a random place
                 init_socket[rand() % init_socket.size()]->b_transport(*txn, myTime);
+                txn = nullptr;
 
 #ifdef DEBUG
                 std::stringstream msg;

--- a/examples/sysc/risc_cpu/bios.h
+++ b/examples/sysc/risc_cpu/bios.h
@@ -82,6 +82,11 @@ struct bios : sc_module {
 	}
   }
 
+  virtual ~bios() {
+    delete [] imemory;
+    delete [] itagmemory;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/examples/sysc/risc_cpu/dcache.h
+++ b/examples/sysc/risc_cpu/dcache.h
@@ -86,6 +86,12 @@ struct dcache : sc_module {
 	}
   }
 
+  virtual ~dcache() {
+    delete [] dmemory;
+    delete [] dsmemory;
+    delete [] dtagmemory;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/examples/sysc/risc_cpu/icache.h
+++ b/examples/sysc/risc_cpu/icache.h
@@ -85,6 +85,11 @@ struct icache : sc_module {
 	}
   }
 
+  virtual ~icache() {
+    delete [] icmemory;
+    delete [] ictagmemory;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/examples/sysc/simple_bus/simple_bus_main.cpp
+++ b/examples/sysc/simple_bus/simple_bus_main.cpp
@@ -44,5 +44,7 @@ int sc_main(int, char **)
 
   sc_start(10000, SC_NS);
 
+  fflush(stdout);
+
   return 0;
 }

--- a/tests/include/tlm/CoreDecouplingLTInitiator.h
+++ b/tests/include/tlm/CoreDecouplingLTInitiator.h
@@ -132,22 +132,24 @@ public:
 
   void run()
   {
-    transaction_type trans;
+    {
+      transaction_type trans;
 
-    while (initTransaction(trans)) {
-      logStartTransation(trans);
-      
-      // exec instr
-      sc_core::sc_time t = mQuantumKeeper.get_local_time();
-      socket->b_transport(trans, t);
-      mQuantumKeeper.set(t);
-      // Target may have added a delay to the quantum -> sync if needed
-      if (mQuantumKeeper.need_sync()) {
-        std::cout << "Sync'ing..." << std::endl;
-        mQuantumKeeper.sync();
+      while (initTransaction(trans)) {
+        logStartTransation(trans);
+
+        // exec instr
+        sc_core::sc_time t = mQuantumKeeper.get_local_time();
+        socket->b_transport(trans, t);
+        mQuantumKeeper.set(t);
+        // Target may have added a delay to the quantum -> sync if needed
+        if (mQuantumKeeper.need_sync()) {
+          std::cout << "Sync'ing..." << std::endl;
+          mQuantumKeeper.sync();
+        }
+
+        logEndTransaction(trans);
       }
-
-      logEndTransaction(trans);
     }
     wait();
   }

--- a/tests/include/tlm/SimpleLTInitiator1.h
+++ b/tests/include/tlm/SimpleLTInitiator1.h
@@ -124,14 +124,17 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    sc_core::sc_time t(sc_core::SC_ZERO_TIME);
-    while (initTransaction(trans)) {
-      logStartTransation(trans);
-      socket->b_transport(trans, t);
-      wait(t);
-      logEndTransaction(trans);
-      t = sc_core::SC_ZERO_TIME;
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
+    {
+      transaction_type trans;
+      sc_core::sc_time t(sc_core::SC_ZERO_TIME);
+      while (initTransaction(trans)) {
+        logStartTransation(trans);
+        socket->b_transport(trans, t);
+        wait(t);
+        logEndTransaction(trans);
+        t = sc_core::SC_ZERO_TIME;
+      }
     }
     wait();
 

--- a/tests/include/tlm/SimpleLTInitiator1_DMI.h
+++ b/tests/include/tlm/SimpleLTInitiator1_DMI.h
@@ -131,73 +131,75 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    phase_type phase;
-    sc_core::sc_time t;
-    
-    while (initTransaction(trans)) {
-      // Create transaction and initialise phase and t
-      phase = tlm::BEGIN_REQ;
-      t = sc_core::SC_ZERO_TIME;
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
+    {
+      transaction_type trans;
+      phase_type phase;
+      sc_core::sc_time t;
 
-      logStartTransation(trans);
+      while (initTransaction(trans)) {
+        // Create transaction and initialise phase and t
+        phase = tlm::BEGIN_REQ;
+        t = sc_core::SC_ZERO_TIME;
 
-      ///////////////////////////////////////////////////////////
-      // DMI handling:
-      // We use the DMI hint to check if it makes sense to ask for
-      // DMI pointers. The pattern is:
-      // - if the address is covered by a DMI region do a DMI access
-      // - otherwise do a normal transaction
-      //   -> check if we get a DMI hint and acquire the DMI pointers if it is
-      //      set
-      ///////////////////////////////////////////////////////////
+        logStartTransation(trans);
 
-      // Check if the address is covered by our DMI region
-      if ( (trans.get_address() >= mDMIData.get_start_address()) &&
-           (trans.get_address() <= mDMIData.get_end_address()) ) {
-          // We can handle the data here. As the logEndTransaction is assuming
-          // something to happen in the data structure, we really need to
-          // do this:
-          trans.set_response_status(tlm::TLM_OK_RESPONSE);
-          sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-              *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
+        ///////////////////////////////////////////////////////////
+        // DMI handling:
+        // We use the DMI hint to check if it makes sense to ask for
+        // DMI pointers. The pattern is:
+        // - if the address is covered by a DMI region do a DMI access
+        // - otherwise do a normal transaction
+        //   -> check if we get a DMI hint and acquire the DMI pointers if it is
+        //      set
+        ///////////////////////////////////////////////////////////
 
-          } else {
-              mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
-          }
-          
-          // Do the wait immediately. Note that doing the wait here eats almost
-          // all the performance anyway, so we only gain something if we're
-          // using temporal decoupling.
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-            wait(mDMIData.get_write_latency());
+        // Check if the address is covered by our DMI region
+        if ( (trans.get_address() >= mDMIData.get_start_address()) &&
+            (trans.get_address() <= mDMIData.get_end_address()) ) {
+            // We can handle the data here. As the logEndTransaction is assuming
+            // something to happen in the data structure, we really need to
+            // do this:
+            trans.set_response_status(tlm::TLM_OK_RESPONSE);
+            sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+                *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
 
-          } else {
-            wait(mDMIData.get_read_latency());
-          }
-          
-          logEndTransaction(trans);
+            } else {
+                mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
+            }
+            // Do the wait immediately. Note that doing the wait here eats almost
+            // all the performance anyway, so we only gain something if we're
+            // using temporal decoupling.
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+              wait(mDMIData.get_write_latency());
 
-      } else { // we need a full transaction
-          sc_dt::uint64 addr = trans.get_address(); //Save address before it is mutated
-          socket->b_transport(trans, t);
-          wait(t);
-          logEndTransaction(trans);
-          
-		  // Acquire DMI pointer on is available:
-          if (trans.is_dmi_allowed())
-          {
-              dmi_type tmp;
-              tmp.init();
-              trans.set_address(addr);  //restore address, in case it was mutated.
-              trans.set_write();
-              if ( socket->get_direct_mem_ptr(trans, tmp)
-                   && tmp.is_write_allowed() )
-              {
-                  mDMIData = tmp;
-              }
-          }
+            } else {
+              wait(mDMIData.get_read_latency());
+            }
+
+            logEndTransaction(trans);
+
+        } else { // we need a full transaction
+            sc_dt::uint64 addr = trans.get_address(); //Save address before it is mutated
+            socket->b_transport(trans, t);
+            wait(t);
+            logEndTransaction(trans);
+
+		        // Acquire DMI pointer on is available:
+            if (trans.is_dmi_allowed())
+            {
+                dmi_type tmp;
+                tmp.init();
+                trans.set_address(addr);  //restore address, in case it was mutated.
+                trans.set_write();
+                if ( socket->get_direct_mem_ptr(trans, tmp)
+                    && tmp.is_write_allowed() )
+                {
+                    mDMIData = tmp;
+                }
+            }
+        }
       }
     }
     wait();

--- a/tests/include/tlm/SimpleLTInitiator2.h
+++ b/tests/include/tlm/SimpleLTInitiator2.h
@@ -119,19 +119,22 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    sc_core::sc_time t;
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
+    {
+      transaction_type trans;
+      sc_core::sc_time t;
 
-    while (initTransaction(trans)) {
-      // Create transaction and initialise t
-      t = sc_core::SC_ZERO_TIME;
+      while (initTransaction(trans)) {
+        // Create transaction and initialise t
+        t = sc_core::SC_ZERO_TIME;
 
-      logStartTransation(trans);
+        logStartTransation(trans);
 
-      socket->b_transport(trans, t);
-      wait(t);
+        socket->b_transport(trans, t);
+        wait(t);
 
-      logEndTransaction(trans);
+        logEndTransaction(trans);
+      }
     }
     wait();
 

--- a/tests/include/tlm/SimpleLTInitiator2_DMI.h
+++ b/tests/include/tlm/SimpleLTInitiator2_DMI.h
@@ -141,75 +141,77 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    sc_core::sc_time t;
-    
-    while (initTransaction(trans)) {
-      // Create transaction and initialise t
-      t = sc_core::SC_ZERO_TIME;
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
+    {
+      transaction_type trans;
+      sc_core::sc_time t;
 
-      logStartTransation(trans);
+      while (initTransaction(trans)) {
+        // Create transaction and initialise t
+        t = sc_core::SC_ZERO_TIME;
 
-      ///////////////////////////////////////////////////////////
-      // DMI handling:
-      // We do *not* use the DMI hint to check if it makes sense to ask for
-      // DMI pointers. So the pattern is:
-      // - if the address is not covered by a DMI region try to acquire DMI
-      //   pointers
-      // - if we have a DMI pointer, do the DMI "transaction"
-      // - otherwise fall back to a normal transaction
-      ///////////////////////////////////////////////////////////
+        logStartTransation(trans);
 
-      std::pair<dmi_type, bool>& dmi_data = getDMIData(trans);
+        ///////////////////////////////////////////////////////////
+        // DMI handling:
+        // We do *not* use the DMI hint to check if it makes sense to ask for
+        // DMI pointers. So the pattern is:
+        // - if the address is not covered by a DMI region try to acquire DMI
+        //   pointers
+        // - if we have a DMI pointer, do the DMI "transaction"
+        // - otherwise fall back to a normal transaction
+        ///////////////////////////////////////////////////////////
 
-      // Check if we need to acquire a DMI pointer
-      if((trans.get_address() < dmi_data.first.get_start_address()) ||
-         (trans.get_address() > dmi_data.first.get_end_address()) )
-      {
-          sc_dt::uint64 address = trans.get_address(); //save original address
-          dmi_data.second =
-            socket->get_direct_mem_ptr(trans,
-                                       dmi_data.first);
-          trans.set_address(address);
+        std::pair<dmi_type, bool>& dmi_data = getDMIData(trans);
+
+        // Check if we need to acquire a DMI pointer
+        if((trans.get_address() < dmi_data.first.get_start_address()) ||
+          (trans.get_address() > dmi_data.first.get_end_address()) )
+        {
+            sc_dt::uint64 address = trans.get_address(); //save original address
+            dmi_data.second =
+              socket->get_direct_mem_ptr(trans,
+                                        dmi_data.first);
+            trans.set_address(address);
+        }
+        // Do DMI "transaction" if we have a valid region
+        if (dmi_data.second &&
+            (trans.get_address() >= dmi_data.first.get_start_address()) &&
+            (trans.get_address() <= dmi_data.first.get_end_address()) )
+        {
+            // We can handle the data here. As the logEndTransaction is assuming
+            // something to happen in the data structure, we really need to
+            // do this:
+            trans.set_response_status(tlm::TLM_OK_RESPONSE);
+            sc_dt::uint64 tmp = trans.get_address() - dmi_data.first.get_start_address();
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND)
+            {
+                *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp] = mData;
+            }
+            else
+            {
+                mData = *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp];
+            }
+
+            // Do the wait immediately. Note that doing the wait here eats almost
+            // all the performance anyway, so we only gain something if we're
+            // using temporal decoupling.
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+              wait(dmi_data.first.get_write_latency());
+
+            } else {
+              wait(dmi_data.first.get_read_latency());
+            }
+        }
+        else // we need a full transaction
+        {
+            socket->b_transport(trans, t);
+            wait(t);
+        }
+        logEndTransaction(trans);
       }
-      // Do DMI "transaction" if we have a valid region
-      if (dmi_data.second &&
-          (trans.get_address() >= dmi_data.first.get_start_address()) &&
-          (trans.get_address() <= dmi_data.first.get_end_address()) )
-      {
-          // We can handle the data here. As the logEndTransaction is assuming
-          // something to happen in the data structure, we really need to
-          // do this:
-          trans.set_response_status(tlm::TLM_OK_RESPONSE);
-          sc_dt::uint64 tmp = trans.get_address() - dmi_data.first.get_start_address();
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND)
-          {
-              *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp] = mData;
-          }
-          else
-          {
-              mData = *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp];
-          }
-          
-          // Do the wait immediately. Note that doing the wait here eats almost
-          // all the performance anyway, so we only gain something if we're
-          // using temporal decoupling.
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-            wait(dmi_data.first.get_write_latency());
-
-          } else {
-            wait(dmi_data.first.get_read_latency());
-          }
-      }
-      else // we need a full transaction
-      {
-          socket->b_transport(trans, t);
-          wait(t);
-      }
-      logEndTransaction(trans);
     }
     wait();
-
   }
 
   // Invalidate DMI pointer(s)

--- a/tests/include/tlm/SimpleLTInitiator3.h
+++ b/tests/include/tlm/SimpleLTInitiator3.h
@@ -119,20 +119,22 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    sc_core::sc_time t;
+    {
+      transaction_type trans;
+      sc_core::sc_time t;
     
-    while (initTransaction(trans)) {
-      // Create transaction and initialise t
-      t = sc_core::SC_ZERO_TIME;
+      while (initTransaction(trans)) {
+        // Create transaction and initialise t
+        t = sc_core::SC_ZERO_TIME;
 
-      logStartTransation(trans);
+        logStartTransation(trans);
 
-      socket->b_transport(trans, t);
-      // Transaction Finished, wait for the returned delay
-      wait(t);
+        socket->b_transport(trans, t);
+        // Transaction Finished, wait for the returned delay
+        wait(t);
 
-      logEndTransaction(trans);
+        logEndTransaction(trans);
+      }
     }
     wait();
 

--- a/tests/include/tlm/SimpleLTInitiator3_DMI.h
+++ b/tests/include/tlm/SimpleLTInitiator3_DMI.h
@@ -139,78 +139,80 @@ public:
 
   void run()
   {
-    transaction_type trans;
-    sc_core::sc_time t;
-    
-    while (initTransaction(trans)) {
-      // Create transaction and initialise t
-      t = sc_core::SC_ZERO_TIME;
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
+    {
+      transaction_type trans;
+      sc_core::sc_time t;
 
-      logStartTransation(trans);
+      while (initTransaction(trans)) {
+        // Create transaction and initialise t
+        t = sc_core::SC_ZERO_TIME;
 
-      ///////////////////////////////////////////////////////////
-      // DMI handling:
-      // We do *not* use the DMI hint to check if it makes sense to ask for
-      // DMI pointers. So the pattern is:
-      // - if the address is not covered by a DMI region try to acquire DMI
-      //   pointers
-      // - if we have a DMI pointer, do the DMI "transaction"
-      // - otherwise fall back to a normal transaction
-      ///////////////////////////////////////////////////////////
+        logStartTransation(trans);
 
-      std::pair<dmi_type, bool>& dmi_data = getDMIData(trans);
+        ///////////////////////////////////////////////////////////
+        // DMI handling:
+        // We do *not* use the DMI hint to check if it makes sense to ask for
+        // DMI pointers. So the pattern is:
+        // - if the address is not covered by a DMI region try to acquire DMI
+        //   pointers
+        // - if we have a DMI pointer, do the DMI "transaction"
+        // - otherwise fall back to a normal transaction
+        ///////////////////////////////////////////////////////////
 
-      // Check if we need to acquire a DMI pointer
-      if((trans.get_address() < dmi_data.first.get_start_address()) ||
-         (trans.get_address() > dmi_data.first.get_end_address()) )
-      {
-          sc_dt::uint64 address = trans.get_address(); //save original address
-          dmi_data.second =
-            socket->get_direct_mem_ptr(trans,
-                                       dmi_data.first);
-          trans.set_address(address);
+        std::pair<dmi_type, bool>& dmi_data = getDMIData(trans);
+
+        // Check if we need to acquire a DMI pointer
+        if((trans.get_address() < dmi_data.first.get_start_address()) ||
+          (trans.get_address() > dmi_data.first.get_end_address()) )
+        {
+            sc_dt::uint64 address = trans.get_address(); //save original address
+            dmi_data.second =
+              socket->get_direct_mem_ptr(trans,
+                                        dmi_data.first);
+            trans.set_address(address);
+        }
+        // Do DMI "transaction" if we have a valid region
+        if (dmi_data.second &&
+            (trans.get_address() >= dmi_data.first.get_start_address()) &&
+            (trans.get_address() <= dmi_data.first.get_end_address()) )
+        {
+            // We can handle the data here. As the logEndTransaction is assuming
+            // something to happen in the data structure, we really need to
+            // do this:
+            trans.set_response_status(tlm::TLM_OK_RESPONSE);
+
+            sc_dt::uint64 tmp = trans.get_address() - dmi_data.first.get_start_address();
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND)
+            {
+                *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp] = mData;
+            }
+            else
+            {
+                mData = *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp];
+            }
+
+            // Do the wait immediately. Note that doing the wait here eats almost
+            // all the performance anyway, so we only gain something if we're
+            // using temporal decoupling.
+            if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+              wait(dmi_data.first.get_write_latency());
+
+            } else {
+              wait(dmi_data.first.get_read_latency());
+            }
+        }
+        else // we need a full transaction
+        {
+            socket->b_transport(trans, t);
+            // wait for the returned delay
+            wait(t);
+        }
+
+        logEndTransaction(trans);
       }
-      // Do DMI "transaction" if we have a valid region
-      if (dmi_data.second &&
-          (trans.get_address() >= dmi_data.first.get_start_address()) &&
-          (trans.get_address() <= dmi_data.first.get_end_address()) )
-      {
-          // We can handle the data here. As the logEndTransaction is assuming
-          // something to happen in the data structure, we really need to
-          // do this:
-          trans.set_response_status(tlm::TLM_OK_RESPONSE);
-
-          sc_dt::uint64 tmp = trans.get_address() - dmi_data.first.get_start_address();
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND)
-          {
-              *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp] = mData;
-          }
-          else
-          {
-              mData = *(unsigned int*)&dmi_data.first.get_dmi_ptr()[tmp];
-          }
-          
-          // Do the wait immediately. Note that doing the wait here eats almost
-          // all the performance anyway, so we only gain something if we're
-          // using temporal decoupling.
-          if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-            wait(dmi_data.first.get_write_latency());
-
-          } else {
-            wait(dmi_data.first.get_read_latency());
-          }
-      }
-      else // we need a full transaction
-      {
-          socket->b_transport(trans, t);
-          // wait for the returned delay
-          wait(t);
-      }
-
-      logEndTransaction(trans);
     }
     wait();
-
   }
 
   // Invalidate DMI pointer(s)

--- a/tests/systemc/1666-2011-compliance/child_proc_control/child_proc_control.cpp
+++ b/tests/systemc/1666-2011-compliance/child_proc_control/child_proc_control.cpp
@@ -63,6 +63,17 @@ struct Top: sc_module
       c0[i] = c1[i] = c2[i] = c3[i] = c4[i] = c5[i] = 0;
     }
   }
+
+  virtual ~Top()
+  {
+    delete [] given_birth;
+    delete [] c0;
+    delete [] c1;
+    delete [] c2;
+    delete [] c3;
+    delete [] c4;
+    delete [] c5;
+  }
   
   int count;
   int f0, f1;

--- a/tests/systemc/1666-2011-compliance/event_list/event_list.cpp
+++ b/tests/systemc/1666-2011-compliance/event_list/event_list.cpp
@@ -42,6 +42,7 @@ using std::endl;
 struct Mod: sc_module
 {
   sc_port<sc_signal_in_if<int>, 0> p; // Multiport
+  sc_event_or_list all_events;
   
   Mod(sc_module_name _name)
   {
@@ -53,7 +54,7 @@ struct Mod: sc_module
   {
     for (;;)
     {
-      wait(all_events());
+      wait(all_events);
       cout << "M::T1 awoke with " << p[0]->read() << p[1]->read() << p[2]->read() 
            << " at " << sc_time_stamp() << " on list" << endl;
     }
@@ -67,30 +68,29 @@ struct Mod: sc_module
            << " at " << sc_time_stamp() << " on list" << endl;
     }
   }
-  sc_event_or_list all_events() const
+
+  void end_of_elaboration() override
   {
     sc_assert( p.size() == 3 );
     
-    sc_event_or_list or_list;
     for (int i = 0; i < p.size(); i++)
-      or_list |= p[i]->default_event();
+      all_events |= p[i]->default_event();
       
-    sc_assert( or_list.size() == 3 );
-    return or_list;
-  }  
+    sc_assert( all_events.size() == 3 );
+  }
  
 };
 
 struct Top: sc_module
 {
   Top(sc_module_name _name)
-  : finished(false)
+  : m("m")
+  , finished(false)
   , count(0)
   {
-    m = new Mod("m");
-    m->p.bind(sig1);
-    m->p.bind(sig2);
-    m->p.bind(sig3);
+    m.p.bind(sig1);
+    m.p.bind(sig2);
+    m.p.bind(sig3);
     SC_THREAD(T);
     SC_METHOD(M);
   }
@@ -105,7 +105,7 @@ struct Top: sc_module
   }
   
   sc_signal<int> sig1, sig2, sig3;
-  Mod* m;
+  Mod m;
   
   sc_event e1, e2, e3, e4;
   bool finished;

--- a/tests/systemc/1666-2011-compliance/method_with_reset/method_with_reset.cpp
+++ b/tests/systemc/1666-2011-compliance/method_with_reset/method_with_reset.cpp
@@ -356,10 +356,12 @@ struct Top: sc_module
     event_list = m3.reset_event() | m3.terminated_event();
     next_trigger(event_list);
   }
+
+  // outside the SC_THREAD to make the leak sanitizer happy (co-routine stacks are not proper cleaned up)
+  sc_event_or_list or_list;
   
   void multiple_reset_handler()
   {
-    sc_event_or_list or_list;
     or_list |= m1.reset_event();
     or_list |= m2.reset_event();
     or_list |= m3.reset_event();

--- a/tests/systemc/1666-2011-compliance/mixed_child_procs/mixed_child_procs.cpp
+++ b/tests/systemc/1666-2011-compliance/mixed_child_procs/mixed_child_procs.cpp
@@ -77,6 +77,17 @@ struct Top: sc_module
     m = sc_spawn(sc_bind(&Top::child_method, this, index++, 3), "m", &opt);
   }
 
+  virtual ~Top()
+  {
+    delete [] given_birth;
+    delete [] f0;
+    delete [] f1;
+    delete [] f2;
+    delete [] f3;
+    delete [] f4;
+    delete [] f5;
+  }
+
   sc_spawn_options opt;
   sc_process_handle t, m;  
   std::exception ex;

--- a/tests/systemc/1666-2011-compliance/sc_vector/sc_vector.cpp
+++ b/tests/systemc/1666-2011-compliance/sc_vector/sc_vector.cpp
@@ -323,9 +323,10 @@ struct Top: sc_module
     SC_THREAD(T2);
   }
   
+  // outside the SC_THREAD to make the leak sanitizer happy (co-routine stacks are not proper cleaned up)
+  sc_event_or_list list;
   void T()
   {
-    sc_event_or_list list;
     for (int i = 0; i < 4; i++)
       list |= sigs[i].default_event();
     for (;;)

--- a/tests/systemc/compliance_1666/test001/test001.cpp
+++ b/tests/systemc/compliance_1666/test001/test001.cpp
@@ -254,6 +254,11 @@ SC_MODULE(Top)
       sensitive << *pp;    //// Sensitivity separated from SC_METHOD DOULOS011
     }
 
+    virtual ~Nested()
+    {
+      delete pp;
+    }
+
   void action() { op = sc_min(3, (*pp).read() + 1); }
 
     sc_out<int> op;        //// Out-of-order declaration DOULOS052
@@ -306,6 +311,19 @@ SC_MODULE(Top)
     modb.p2(c2);
     modb.p3(c3);
     modb.p4(ms);
+  }
+
+  virtual ~Top()
+  {
+    delete link->link->m;
+    delete link->link->s;
+    delete link->link->p;
+    delete link->link;
+    delete link->p;
+    delete link->m;
+    delete link;
+
+    delete sig;
   }
 
 };

--- a/tests/systemc/compliance_1666/test234/test234.cpp
+++ b/tests/systemc/compliance_1666/test234/test234.cpp
@@ -19,10 +19,17 @@ struct Chan: i_f, sc_object
 
 struct Port: sc_port<i_f,0>
 {
-  sc_event_finder& find_event() const
+  Port() : m_event_finder(*this, &i_f::event)
   {
-    return *new sc_event_finder_t<i_f>( *this, &i_f::event );
   }
+
+  sc_event_finder& find_event()
+  {
+    return m_event_finder;
+  }
+
+  private:
+  sc_event_finder_t<i_f> m_event_finder;
 };
 
 SC_MODULE(M)
@@ -75,14 +82,13 @@ SC_MODULE(M)
 
 SC_MODULE(Top)
 {
-  M *m;
+  M m;
   Chan chan1, chan2, chan3;
-  SC_CTOR(Top)
+  SC_CTOR(Top): m("m")
   {
-    m = new M("m");
-    m->mp(chan1);
-    m->mp(chan2);
-    m->mp(chan3);
+    m.mp(chan1);
+    m.mp(chan2);
+    m.mp(chan3);
     SC_THREAD(T);
   }
   void T()

--- a/tests/systemc/kernel/dynamic_processes/test06/test06.cpp
+++ b/tests/systemc/kernel/dynamic_processes/test06/test06.cpp
@@ -49,21 +49,21 @@ void p3() {
 
 void p2() {
   cerr << sc_time_stamp() << ":entering p2, spawning p3" << endl;
-  sc_spawn(sc_bind(&p3));
+  sc_spawn(&p3);
   wait(20, SC_NS);
   cerr << sc_time_stamp() << ":exiting p2" << endl;
 }
 
 void p1() {
   cerr << sc_time_stamp() << ":entering p1, spawning p2" << endl;
-  sc_spawn(sc_bind(&p2));
+  sc_spawn(&p2);
   wait(10, SC_NS);
   cerr << sc_time_stamp() << ":exiting p1" << endl;
 }
 
 void p0() {
   cerr << sc_time_stamp() << ":entering p0, spawning p1" << endl;
-  sc_spawn(sc_bind(&p1));
+  sc_spawn(&p1);
   cerr << sc_time_stamp() << ":exiting p0" << endl;
 }
 

--- a/tests/systemc/kernel/dynamic_processes/test07/test07.cpp
+++ b/tests/systemc/kernel/dynamic_processes/test07/test07.cpp
@@ -60,13 +60,17 @@ SC_MODULE(DUT)
 	{
 		cout << sc_time_stamp() << " callback" << endl;
 	}
+
 	void thread()
 	{
-		sc_spawn_options options;
-		options.spawn_method();
-		options.set_sensitivity( &m_port );
-		options.dont_initialize();
-		sc_spawn( sc_bind(&DUT::method,this), "method", &options );
+  		// scope to free `options` memory (co-routine stacks are not proper cleaned up at simulation end)
+		{
+			sc_spawn_options options;
+			options.spawn_method();
+			options.set_sensitivity( &m_port );
+			options.dont_initialize();
+			sc_spawn( sc_bind(&DUT::method,this), "method", &options );
+		}
 		for ( bool value=true;; value = !value)
 		{
 			wait();

--- a/tests/systemc/kernel/process_control/test06/test06.cpp
+++ b/tests/systemc/kernel/process_control/test06/test06.cpp
@@ -84,32 +84,35 @@ public:
 
     wait();
 
-    // copy children (needed, since children may get reordered)
-    std::vector< sc_object* > children =
-      sc_get_current_process_handle().get_child_objects();
-
-    std::vector< sc_object* >::const_iterator it = children.begin();
-
-    while( it != children.end() )
+    // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
     {
-      sc_process_handle h( *it++ );
-      sc_assert( h.valid() );
+      // copy children (needed, since children may get reordered)
+      std::vector< sc_object* > children =
+        sc_get_current_process_handle().get_child_objects();
 
-      std::cout << h.name() << " "
-                << "kill requested "
-                << "(" << h.get_process_object()->kind() << ") "
+      std::vector< sc_object* >::const_iterator it = children.begin();
+
+      while( it != children.end() )
+      {
+        sc_process_handle h( *it++ );
+        sc_assert( h.valid() );
+
+        std::cout << h.name() << " "
+                  << "kill requested "
+                  << "(" << h.get_process_object()->kind() << ") "
+                  << "(" << sc_time_stamp() << " @ " << sc_delta_count() << ")"
+                  << std::endl;
+
+        h.kill( SC_INCLUDE_DESCENDANTS );
+      }
+
+      wait();
+
+      std::cout << sc_get_current_process_handle().name()
+                << " ended "
                 << "(" << sc_time_stamp() << " @ " << sc_delta_count() << ")"
                 << std::endl;
-
-      h.kill( SC_INCLUDE_DESCENDANTS );
-    }
-
-    wait();
-
-    std::cout << sc_get_current_process_handle().name()
-              << " ended "
-              << "(" << sc_time_stamp() << " @ " << sc_delta_count() << ")"
-              << std::endl;
+  }
 
     wait();
     sc_stop();

--- a/tests/systemc/kernel/sc_event/test15/event_triggered.cpp
+++ b/tests/systemc/kernel/sc_event/test15/event_triggered.cpp
@@ -117,9 +117,11 @@ private:
     CHECK( event_return.triggered() );
   }
 
+  // outside the SC_THREAD to make the leak sanitizer happy (co-routine stacks are not proper cleaned up)
+  sc_event_or_list events_or; // even events only
+
   void consumer_dynamic()
   {
-    sc_event_or_list events_or; // even events only
     for(unsigned i = 0; i < events.size(); i+=2)
       events_or |= events[i];
 

--- a/tests/systemc/misc/ieee1666_2023/5.7.3/5.7.3.cpp
+++ b/tests/systemc/misc/ieee1666_2023/5.7.3/5.7.3.cpp
@@ -43,9 +43,12 @@ class chan_class : public if_class, public sc_core::sc_prim_channel {
 template<int N=1>
 class port_class : public sc_core::sc_port<if_class,N> {
   public:
-    sc_core::sc_event_finder& event_finder() const {
-      return *new sc_core::sc_event_finder_t<if_class>(*this, &if_class::ev_func);
+    port_class() : m_event_finder(*this, &if_class::ev_func) {}
+    sc_core::sc_event_finder& event_finder() {
+      return m_event_finder;
     }
+  private:
+    sc_core::sc_event_finder_t<if_class> m_event_finder;
 };
 
 SC_MODULE(mod_class)

--- a/tests/systemc/misc/sim_tests/biquad/biquad2/delay_line.h
+++ b/tests/systemc/misc/sim_tests/biquad/biquad2/delay_line.h
@@ -64,6 +64,10 @@ SC_MODULE( delay_line )
     line = new float[delay];
   }
 
+  virtual ~delay_line() {
+    delete[] line;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/tests/systemc/misc/sim_tests/biquad/biquad2/op_queue.h
+++ b/tests/systemc/misc/sim_tests/biquad/biquad2/op_queue.h
@@ -69,6 +69,10 @@ SC_MODULE( op_queue )
     queue = new float[queue_size];
   }
 
+  virtual ~op_queue() {
+    delete[] queue;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/tests/systemc/misc/sim_tests/biquad/biquad3/delay_line.h
+++ b/tests/systemc/misc/sim_tests/biquad/biquad3/delay_line.h
@@ -65,6 +65,10 @@ SC_MODULE( delay_line )
     sensitive << in;
   }
 
+  virtual ~delay_line() {
+    delete[] line;
+  }
+
   // Process functionality in member function below
   void entry();
 };

--- a/tests/systemc/misc/sim_tests/simple_cpu/simple_cpu.cpp
+++ b/tests/systemc/misc/sim_tests/simple_cpu/simple_cpu.cpp
@@ -85,6 +85,10 @@ SC_MODULE( exec_decode )
     program_counter.write(pc);
   }
 
+  virtual ~exec_decode() {
+    delete[] data_mem;
+  }
+
   // Functionality
   void entry();
 };
@@ -219,6 +223,10 @@ SC_MODULE( fetch )
       prog_mem[size++] = mem_word;
     }
     instruction.write(0);
+  }
+
+  virtual ~fetch() {
+    delete[] prog_mem;
   }
 
   // Functionality

--- a/tests/tlm/cancel_all/cancel_all.cpp
+++ b/tests/tlm/cancel_all/cancel_all.cpp
@@ -21,11 +21,12 @@ SC_MODULE(Test_peq_with_cb)
   {
     section = 1;
 
-    tlm::tlm_generic_payload *trans;
+    std::vector<tlm::tlm_generic_payload*> trans_vec;
     tlm::tlm_phase phase;
     for (int i = 0; i < 50; i++)
     {
-      trans = new tlm::tlm_generic_payload;
+      tlm::tlm_generic_payload *trans = new tlm::tlm_generic_payload;
+      trans_vec.push_back(trans);
       trans->set_address(i);
       m_peq.notify( *trans, phase, sc_time(rand() % 100, SC_NS) );
     }
@@ -33,17 +34,29 @@ SC_MODULE(Test_peq_with_cb)
 
     m_peq.cancel_all();
     cout << "cancel_all\n";
+    while(!trans_vec.empty())
+    {
+      delete trans_vec.back();
+      trans_vec.pop_back();
+    }
+
     section = 2;
 
     for (int i = 100; i < 150; i++)
     {
-      trans = new tlm::tlm_generic_payload;
+      tlm::tlm_generic_payload *trans = new tlm::tlm_generic_payload;
+      trans_vec.push_back(trans);
       trans->set_address(i);
       m_peq.notify( *trans, phase, sc_time(rand() % 100, SC_NS) );
     }
     wait(50, SC_NS);
     m_peq.cancel_all();
     cout << "cancel_all\n";
+    while(!trans_vec.empty())
+    {
+      delete trans_vec.back();
+      trans_vec.pop_back();
+    }
 
     wait(50, SC_NS);
   }
@@ -91,10 +104,11 @@ SC_MODULE(Test_peq_with_get)
 
     section = 3;
 
-    tlm::tlm_generic_payload *trans;
+    std::vector<tlm::tlm_generic_payload*> trans_vec;
     for (int i = 0; i < 50; i++)
     {
-      trans = new tlm::tlm_generic_payload;
+      tlm::tlm_generic_payload *trans = new tlm::tlm_generic_payload;
+      trans_vec.push_back(trans);
       trans->set_address(i);
       m_peq.notify( *trans, sc_time(rand() % 100, SC_NS) );
     }
@@ -102,17 +116,28 @@ SC_MODULE(Test_peq_with_get)
 
     m_peq.cancel_all();
     cout << "cancel_all\n";
+    while(!trans_vec.empty())
+    {
+      delete trans_vec.back();
+      trans_vec.pop_back();
+    }
     section = 4;
 
     for (int i = 100; i < 150; i++)
     {
-      trans = new tlm::tlm_generic_payload;
+      tlm::tlm_generic_payload *trans = new tlm::tlm_generic_payload;
+      trans_vec.push_back(trans);
       trans->set_address(i);
       m_peq.notify( *trans, sc_time(rand() % 100, SC_NS) );
     }
     wait(50, SC_NS);
     m_peq.cancel_all();
     cout << "cancel_all\n";
+    while(!trans_vec.empty())
+    {
+      delete trans_vec.back();
+      trans_vec.pop_back();
+    }
 
     wait(50, SC_NS);
   }

--- a/tests/tlm/nb2b_adapter/mm.h
+++ b/tests/tlm/nb2b_adapter/mm.h
@@ -18,6 +18,7 @@ public:
 
     while (free_list)
     {
+      access* node = free_list;
       ptr = free_list->trans;
 
       // Delete generic payload and all extensions
@@ -25,6 +26,7 @@ public:
       delete ptr;
 
       free_list = free_list->next;
+      delete node;
     }
 
     while (empties)

--- a/tests/tlm/nb2b_adapter/nb2b_adapter.cpp
+++ b/tests/tlm/nb2b_adapter/nb2b_adapter.cpp
@@ -235,8 +235,12 @@ struct Interconnect: sc_module
 
     if (status == tlm::TLM_COMPLETED)
     {
-      accessor(trans).clear_extension(ext);
-      delete ext;
+      accessor(trans).get_extension(ext);
+      if (ext)
+      {
+        accessor(trans).clear_extension(ext);
+        delete ext;
+      }
     }
 
     return status;
@@ -341,24 +345,23 @@ struct Target: sc_module
 
 SC_MODULE(Top)
 {
-  Initiator    *initiator1;
-  Initiator    *initiator2;
-  Interconnect *interconnect;
-  Target       *target1;
-  Target       *target2;
+  Initiator    initiator1;
+  Initiator    initiator2;
+  Interconnect interconnect;
+  Target       target1;
+  Target       target2;
 
   SC_CTOR(Top)
+    : initiator1("initiator1")
+    , initiator2("initiator2")
+    , interconnect("interconnect", 1)
+    , target1("target1")
+    , target2("target2")
   {
-    initiator1   = new Initiator   ("initiator1");
-    initiator2   = new Initiator   ("initiator2");
-    interconnect = new Interconnect("interconnect", 1);
-    target1      = new Target      ("target1");
-    target2      = new Target      ("target2");
-
-    initiator1->socket.bind(interconnect->targ_socket);
-    initiator2->socket.bind(interconnect->targ_socket);
-    interconnect->init_socket.bind(target1->socket);
-    interconnect->init_socket.bind(target2->socket);
+    initiator1.socket.bind(interconnect.targ_socket);
+    initiator2.socket.bind(interconnect.targ_socket);
+    interconnect.init_socket.bind(target1.socket);
+    interconnect.init_socket.bind(target2.socket);
   }
 };
 

--- a/tests/tlm/static_extensions/ext2gp/SimpleLTInitiator_ext.h
+++ b/tests/tlm/static_extensions/ext2gp/SimpleLTInitiator_ext.h
@@ -131,99 +131,99 @@ public:
 
   void run()
   {
-      transaction_type trans;
-      phase_type phase;
-      sc_core::sc_time t;
-      // make sure that our transaction has the proper extension:
-      my_extension* tmp_ext = new my_extension();
-      tmp_ext->m_data = 11;
-      
-      trans.set_extension(tmp_ext);
-      
-      while (initTransaction(trans))
-      {
-          // Create transaction and initialise phase and t
-          phase = tlm::BEGIN_REQ;
-          t = sc_core::SC_ZERO_TIME;
-          
-          logStartTransation(trans);
-          ///////////////////////////////////////////////////////////
-          // DMI handling:
-          // We use the DMI hint to check if it makes sense to ask for
-          // DMI pointers. The pattern is:
-          // - if the address is covered by a DMI region do a DMI access
-          // - otherwise do a normal transaction
-          //   -> check if we get a DMI hint and acquire the DMI pointers if it
-          //      is set
-          ///////////////////////////////////////////////////////////
-          
-          // Check if the address is covered by our DMI region
-          if ( (trans.get_address() >= mDMIData.get_start_address()) &&
-               (trans.get_address() <= mDMIData.get_end_address()) )
-          {
-              // We can handle the data here. As the logEndTransaction is
-              // assuming something to happen in the data structure, we really
-              // need to do this:
-              trans.set_response_status(tlm::TLM_OK_RESPONSE);
-              sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
-              if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-                  *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
-                  
-              } else {
-                  mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
-              }
-              
-              // Do the wait immediately. Note that doing the wait here eats
-              //  almost all the performance anyway, so we only gain something
-              // if we're using temporal decoupling.
-              if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-                  wait(mDMIData.get_write_latency());
-                  
-              } else {
-                  wait(mDMIData.get_read_latency());
-              }
+    {
+       transaction_type trans;
+       phase_type phase;
+       sc_core::sc_time t;
+       // make sure that our transaction has the proper extension:
+       my_extension* tmp_ext = new my_extension();
+       tmp_ext->m_data = 11;
 
-              logEndTransaction(trans);
-              
-          } else { // we need a full transaction
-              switch (socket->nb_transport_fw(trans, phase, t)) {
-              case tlm::TLM_COMPLETED:
-                  // Transaction Finished, wait for the returned delay
-                  wait(t);
-                  break;
-                  
-              case tlm::TLM_ACCEPTED:
-              case tlm::TLM_UPDATED:
-                  // Transaction not yet finished, wait for the end of it
-                  wait(mEndEvent);
-                  break;
-                  
-              default:
-                  sc_assert(0); exit(1);
-              };
-    
-              logEndTransaction(trans);
+       trans.set_extension(tmp_ext);
 
-              // Acquire DMI pointer if one is available:
-              if (trans.is_dmi_allowed())
-              {
-                  trans.set_write();
-                  dmi_type tmp;
-                  if (socket->get_direct_mem_ptr(trans,
-                                                 tmp))
-                  {
-                      // FIXME: No support for separate read/write ranges
-                      sc_assert(tmp.is_read_write_allowed());
-                      mDMIData = tmp;
-                  }
-              }
-          }
-      }
-      delete tmp_ext;
-      wait();
-      
+       while (initTransaction(trans))
+       {
+           // Create transaction and initialise phase and t
+           phase = tlm::BEGIN_REQ;
+           t = sc_core::SC_ZERO_TIME;
+
+           logStartTransation(trans);
+           ///////////////////////////////////////////////////////////
+           // DMI handling:
+           // We use the DMI hint to check if it makes sense to ask for
+           // DMI pointers. The pattern is:
+           // - if the address is covered by a DMI region do a DMI access
+           // - otherwise do a normal transaction
+           //   -> check if we get a DMI hint and acquire the DMI pointers if it
+           //      is set
+           ///////////////////////////////////////////////////////////
+
+           // Check if the address is covered by our DMI region
+           if ( (trans.get_address() >= mDMIData.get_start_address()) &&
+                (trans.get_address() <= mDMIData.get_end_address()) )
+           {
+               // We can handle the data here. As the logEndTransaction is
+               // assuming something to happen in the data structure, we really
+               // need to do this:
+               trans.set_response_status(tlm::TLM_OK_RESPONSE);
+               sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
+               if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+                   *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
+
+               } else {
+                   mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
+               }
+
+               // Do the wait immediately. Note that doing the wait here eats
+               //  almost all the performance anyway, so we only gain something
+               // if we're using temporal decoupling.
+               if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+                   wait(mDMIData.get_write_latency());
+
+               } else {
+                   wait(mDMIData.get_read_latency());
+               }
+
+               logEndTransaction(trans);
+
+           } else { // we need a full transaction
+               switch (socket->nb_transport_fw(trans, phase, t)) {
+               case tlm::TLM_COMPLETED:
+                   // Transaction Finished, wait for the returned delay
+                   wait(t);
+                   break;
+
+               case tlm::TLM_ACCEPTED:
+               case tlm::TLM_UPDATED:
+                   // Transaction not yet finished, wait for the end of it
+                   wait(mEndEvent);
+                   break;
+
+               default:
+                   sc_assert(0); exit(1);
+               };
+
+               logEndTransaction(trans);
+
+               // Acquire DMI pointer if one is available:
+               if (trans.is_dmi_allowed())
+               {
+                   trans.set_write();
+                   dmi_type tmp;
+                   if (socket->get_direct_mem_ptr(trans,
+                                                  tmp))
+                   {
+                       // FIXME: No support for separate read/write ranges
+                       sc_assert(tmp.is_read_write_allowed());
+                       mDMIData = tmp;
+                   }
+               }
+           }
+       }
+    }
+    wait();
   }
-  
+
   sync_enum_type myNBTransport(transaction_type& trans,
                                phase_type& phase,
                                sc_core::sc_time& t)

--- a/tests/tlm/static_extensions/ext2gp2ext/SimpleLTInitiator_ext.h
+++ b/tests/tlm/static_extensions/ext2gp2ext/SimpleLTInitiator_ext.h
@@ -131,97 +131,98 @@ public:
 
   void run()
   {
-      transaction_type trans;
-      phase_type phase;
-      sc_core::sc_time t;
-      // make sure that our transaction has the proper extension:
-      my_extension* tmp_ext = new my_extension();
-      tmp_ext->m_data = 11;
-      
-      trans.set_extension(tmp_ext);
-      
-      while (initTransaction(trans))
+      // scope needed to free the memory of the local variables (co-routine stacks are not proper cleaned up at simulation end)
       {
-          // Create transaction and initialise phase and t
-          phase = tlm::BEGIN_REQ;
-          t = sc_core::SC_ZERO_TIME;
-          
-          logStartTransation(trans);
-          ///////////////////////////////////////////////////////////
-          // DMI handling:
-          // We use the DMI hint to check if it makes sense to ask for
-          // DMI pointers. The pattern is:
-          // - if the address is covered by a DMI region do a DMI access
-          // - otherwise do a normal transaction
-          //   -> check if we get a DMI hint and acquire the DMI pointers if it
-          //      is set
-          ///////////////////////////////////////////////////////////
-          
-          // Check if the address is covered by our DMI region
-          if ( (trans.get_address() >= mDMIData.get_start_address()) &&
-               (trans.get_address() <= mDMIData.get_end_address()) )
+          transaction_type trans;
+          phase_type phase;
+          sc_core::sc_time t;
+          // make sure that our transaction has the proper extension:
+          my_extension* tmp_ext = new my_extension();
+          tmp_ext->m_data = 11;
+
+          trans.set_extension(tmp_ext);
+
+          while (initTransaction(trans))
           {
-              // We can handle the data here. As the logEndTransaction is
-              // assuming something to happen in the data structure, we really
-              // need to do this:
-              trans.set_response_status(tlm::TLM_OK_RESPONSE);
-              sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
-              if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-                  *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
-                  
-              } else {
-                  mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
-              }
-              
-              // Do the wait immediately. Note that doing the wait here eats
-              //  almost all the performance anyway, so we only gain something
-              // if we're using temporal decoupling.
-              if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
-                  wait(mDMIData.get_write_latency());
-                  
-              } else {
-                  wait(mDMIData.get_read_latency());
-              }
+              // Create transaction and initialise phase and t
+              phase = tlm::BEGIN_REQ;
+              t = sc_core::SC_ZERO_TIME;
 
-              logEndTransaction(trans);
-              
-          } else { // we need a full transaction
-              switch (socket->nb_transport_fw(trans, phase, t)) {
-              case tlm::TLM_COMPLETED:
-                  // Transaction Finished, wait for the returned delay
-                  wait(t);
-                  break;
-                  
-              case tlm::TLM_ACCEPTED:
-              case tlm::TLM_UPDATED:
-                  // Transaction not yet finished, wait for the end of it
-                  wait(mEndEvent);
-                  break;
-                  
-              default:
-                  sc_assert(0); exit(1);
-              };
-    
-              logEndTransaction(trans);
+              logStartTransation(trans);
+              ///////////////////////////////////////////////////////////
+              // DMI handling:
+              // We use the DMI hint to check if it makes sense to ask for
+              // DMI pointers. The pattern is:
+              // - if the address is covered by a DMI region do a DMI access
+              // - otherwise do a normal transaction
+              //   -> check if we get a DMI hint and acquire the DMI pointers if it
+              //      is set
+              ///////////////////////////////////////////////////////////
 
-              // Acquire DMI pointer if one is available:
-              if (trans.is_dmi_allowed())
+              // Check if the address is covered by our DMI region
+              if ( (trans.get_address() >= mDMIData.get_start_address()) &&
+                   (trans.get_address() <= mDMIData.get_end_address()) )
               {
-                  trans.set_write();
-                  dmi_type tmp;
-                  if (socket->get_direct_mem_ptr(trans,
-                                                 tmp))
+                  // We can handle the data here. As the logEndTransaction is
+                  // assuming something to happen in the data structure, we really
+                  // need to do this:
+                  trans.set_response_status(tlm::TLM_OK_RESPONSE);
+                  sc_dt::uint64 tmp = trans.get_address() - mDMIData.get_start_address();
+                  if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+                      *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp] = mData;
+
+                  } else {
+                      mData = *(unsigned int*)&mDMIData.get_dmi_ptr()[tmp];
+                  }
+
+                  // Do the wait immediately. Note that doing the wait here eats
+                  //  almost all the performance anyway, so we only gain something
+                  // if we're using temporal decoupling.
+                  if (trans.get_command() == tlm::TLM_WRITE_COMMAND) {
+                      wait(mDMIData.get_write_latency());
+
+                  } else {
+                      wait(mDMIData.get_read_latency());
+                  }
+
+                  logEndTransaction(trans);
+
+              } else { // we need a full transaction
+                  switch (socket->nb_transport_fw(trans, phase, t)) {
+                  case tlm::TLM_COMPLETED:
+                      // Transaction Finished, wait for the returned delay
+                      wait(t);
+                      break;
+
+                  case tlm::TLM_ACCEPTED:
+                  case tlm::TLM_UPDATED:
+                      // Transaction not yet finished, wait for the end of it
+                      wait(mEndEvent);
+                      break;
+
+                  default:
+                      sc_assert(0); exit(1);
+                  };
+
+                  logEndTransaction(trans);
+
+                  // Acquire DMI pointer if one is available:
+                  if (trans.is_dmi_allowed())
                   {
-                      // FIXME: No support for separate read/write ranges
-                      sc_assert(tmp.is_read_write_allowed());
-                      mDMIData = tmp;
+                      trans.set_write();
+                      dmi_type tmp;
+                      if (socket->get_direct_mem_ptr(trans,
+                                                     tmp))
+                      {
+                          // FIXME: No support for separate read/write ranges
+                          sc_assert(tmp.is_read_write_allowed());
+                          mDMIData = tmp;
+                      }
                   }
               }
           }
       }
-      delete tmp_ext;
       wait();
-      
   }
   
   sync_enum_type myNBTransport(transaction_type& trans,


### PR DESCRIPTION
* Fix the examples and test so the asan CI pipelines pass

Main changes:
* Add destructors in test classes to free memory allocated in the constructor
* When `sc_bind` is used with a non-member function without parameters (e.g., `sc_spawn(sc_bind(&p3))`), we get a deprecation warning because internally, `std::result_of` is used, which is deprecated in C++17.
* When local variables are used in an `SC_THREAD` which is still active at the end of the simulation (e.g., because it waits on an event that is not notified anymore), the destructors of the local variables are not called at the simulation end (see #153). To fix this issue in the tests, I added scopes around local variables in `SC_THREAD`s (if possible), or I made them member variables of the corresponding classes. I added comments (_co-routine stacks are not proper cleaned up_) so those changes can be reverted if the issue is resolved in the future.

systemc/misc/sim_tests/biquad/biquad1 and systemc/misc/sim_tests/biquad/biquad3 still fail on ubuntu-arm (20.04, linux/arm64, clang-shared-regression-asan) due to floating point rounding errors.