### PR TITLE
CI improvements from SystemC Sprint

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/amd64]
         target: [clang-shared-regression-asan]
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/arm64]
         target: [clang-shared-regression-asan]
     steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/amd64]
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/arm64]
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/amd64]
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/arm64]
         target: [gcc-shared-regression, clang-shared-regression]
     steps:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/amd64]
         target: [clang-shared-regression-tsan]
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/arm64]
         target: [clang-shared-regression-tsan]
     steps:

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/amd64]
         target: [clang-shared-regression-ubsan]
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.04, 22.04, 24.04]
+        version: [22.04, 24.04]
         platform: [linux/arm64]
         target: [clang-shared-regression-ubsan]
     steps:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,19 @@ fi
 # Build with -Werror by default
 CXX_FLAGS="-Werror"
 
+# Don't build with -Werror on AlmaLinux 8 on arm64 hosts
+# GCC 8.5 does not ignore false positive -Wshift-negative-value warning
+if [[ -f /etc/os-release ]]; then
+  . /etc/os-release
+
+  ARCH=$(uname -m)
+
+  if [[ "$ID" == "almalinux" && "$VERSION_ID" == 8* ]] && \
+     [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    CXX_FLAGS=""
+  fi
+fi
+
 case "$SYSTEMC_CI_TARGET" in
   gcc-shared)
     CC=gcc

--- a/tests/systemc/misc/sim_tests/simple_cpu/simple_cpu.cpp
+++ b/tests/systemc/misc/sim_tests/simple_cpu/simple_cpu.cpp
@@ -66,10 +66,11 @@ SC_MODULE( exec_decode )
 
     // Initialize the data memory from file datamem
     FILE *fp = fopen("simple_cpu/datamem", "r");
-    if (fp == (FILE *) 0) return; // No data mem file to read
+    if (fp == (FILE *) 0) assert(); // No data mem file to read
     // First field in this file is the size of data memory desired
     int size;
-    fscanf(fp, "%d", &size);
+    int ret = fscanf(fp, "%d", &size);
+    (void) ret;
     data_mem = new unsigned[size];
     if (data_mem == (unsigned *) 0) {
       printf("Not enough memory left\n");
@@ -207,7 +208,8 @@ SC_MODULE( fetch )
     if (fp == (FILE *) 0) return; // No prog mem file to read
     // First field in this file is the size of program memory desired
     int size;
-    fscanf(fp, "%d", &size);
+    int ret = fscanf(fp, "%d", &size);
+    (void) ret;
     prog_mem = new unsigned[size];
     if (prog_mem == (unsigned *) 0) {
       printf("Not enough memory left\n");

--- a/tests/systemc/misc/user_guide/chpt3.1/sg.cpp
+++ b/tests/systemc/misc/user_guide/chpt3.1/sg.cpp
@@ -47,7 +47,8 @@ void stimgen::entry()
   file = fopen("./chpt3.1/testcase", "r");
   
   while (true) {
-    fscanf(file, "%c", &c);
+    int ret = fscanf(file, "%c", &c);
+    (void) ret;
     data_ready.write(true);
     stream.write(c);
     wait();


### PR DESCRIPTION
- It seems we cannot support -Werror on AlmaLinux 8 on arm64 hosts, because the pragmas introduced by pah do not work on this GCC version. Looks like a compiler bug to me, so we build without error on AlmaLinux 8 Arm hosts now.
- Removed Ubuntu 20.04 from CI to improve CI runtime. 20.04 is EOL, we should add 26.04, but let's cleanup the CI first.
- Some test fixes in regressions to get rid of warnings.