### PR TITLE
Remove nonstandard MSVC ostream opfx usage

### DIFF
--- a/src/sysc/datatypes/int/sc_int64_io.cpp
+++ b/src/sysc/datatypes/int/sc_int64_io.cpp
@@ -151,17 +151,17 @@ write_uint64(::std::ostream& os, uint64 val, int sign)
                 goto fail;
         }
     }
-    os.osfx();
     return;
 fail:
     //os.set(::std::ios::badbit);
-    os.osfx();
+    return;
 }
 
 ::std::ostream&
 operator << ( ::std::ostream& os, int64 n )
 {
-    if (os.opfx()) {
+    ::std::ostream::sentry sentry(os);
+    if (sentry) {
         int sign = 1;
         uint64 abs_n = (uint64) n;
         if (n < 0 && (os.flags() & (::std::ios::oct|::std::ios::hex)) == 0) {
@@ -176,7 +176,8 @@ operator << ( ::std::ostream& os, int64 n )
 ::std::ostream&
 operator << ( ::std::ostream& os, uint64 n )
 {
-    if (os.opfx()) {
+    ::std::ostream::sentry sentry(os);
+    if (sentry) {
         sc_dt::write_uint64(os, n, 0);
     }
     return os;


### PR DESCRIPTION
Replace the removed MSVC STL `opfx`/`osfx` extension points in the 64-bit integer stream insertion operators with standard `std::ostream::sentry` handling.

This keeps the MSVC-specific formatting helper compatible with newer MSVC STL versions, including MSVC 19.51 where the nonstandard hooks have been removed.

This change was authored by GPT-5.5.

These non-standard functions were deprecated by https://github.com/microsoft/STL/pull/4006 and removed by https://github.com/microsoft/STL/pull/5834 . This change is necessary to build systemc with Visual Studio 2026 18.6.0 / MSVC 19.51.