### PR TITLE
ci: use actions/checkout@v6

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -15,7 +15,7 @@ jobs:
         target: [clang-shared-regression-asan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -30,7 +30,7 @@ jobs:
         target: [clang-shared-regression-asan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -45,7 +45,7 @@ jobs:
         target: [clang-shared-regression-asan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -60,7 +60,7 @@ jobs:
         target: [clang-shared-regression-asan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -73,7 +73,7 @@ jobs:
         target: [clang-shared-regression-asan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -30,7 +30,7 @@ jobs:
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -45,7 +45,7 @@ jobs:
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -60,7 +60,7 @@ jobs:
         target: [gcc-shared, gcc-static, clang-shared, clang-static]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -73,7 +73,7 @@ jobs:
         target: [clang-shared, clang-static]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         cmake -B BUILD/RELEASE/BUILD .

--- a/.github/workflows/regressions.yml
+++ b/.github/workflows/regressions.yml
@@ -15,7 +15,7 @@ jobs:
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -30,7 +30,7 @@ jobs:
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -45,7 +45,7 @@ jobs:
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -60,7 +60,7 @@ jobs:
         target: [gcc-shared-regression, clang-shared-regression]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -73,7 +73,7 @@ jobs:
         target: [clang-shared-regression]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         cmake -B BUILD/RELEASE/BUILD -DENABLE_REGRESSION=true .

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -15,7 +15,7 @@ jobs:
         target: [clang-shared-regression-tsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -30,7 +30,7 @@ jobs:
         target: [clang-shared-regression-tsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -45,7 +45,7 @@ jobs:
         target: [clang-shared-regression-tsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -60,7 +60,7 @@ jobs:
         target: [clang-shared-regression-tsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -73,7 +73,7 @@ jobs:
         target: [clang-shared-regression-tsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -15,7 +15,7 @@ jobs:
         target: [clang-shared-regression-ubsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -30,7 +30,7 @@ jobs:
         target: [clang-shared-regression-ubsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -45,7 +45,7 @@ jobs:
         target: [clang-shared-regression-ubsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg UBUNTU_VERSION=${{ matrix.version }} -f docker/ubuntu.dockerfile .
@@ -60,7 +60,7 @@ jobs:
         target: [clang-shared-regression-ubsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         docker buildx build --platform ${{ matrix.platform }} -t systemc_test --build-arg ALMA_VERSION=${{ matrix.version }} -f docker/alma.dockerfile .
@@ -73,7 +73,7 @@ jobs:
         target: [clang-shared-regression-ubsan]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build
       run: |
         SYSTEMC_CI_TARGET=${{ matrix.target }} SYSTEMC_SRC_PATH=$PWD docker/entrypoint.sh


### PR DESCRIPTION
v4 is deprecated with all node v20 actions.

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.