### PR TITLE
rename SC_LOG macros

### DIFF
--- a/src/sysc/kernel/sc_simcontext.cpp
+++ b/src/sysc/kernel/sc_simcontext.cpp
@@ -2076,7 +2076,7 @@ SC_API void sc_unregister_stage_callback(sc_stage_callback_if & cb,
 // Implementation defined Dynamic log verbosity dispatch
 //
 void sc_simcontext::set_log_verbosity_fn(
-    std::function<sc_core::sc_log_level(sc_log_logger_cache &, const char *, int, std::string_view)> fn)
+    std::function<sc_core::sc_verbosity(sc_log_logger_cache &, const char *, int, std::string_view)> fn)
 {
   if (dynamic_log_verbosity) {
     SC_REPORT_WARNING(SC_LOG_OVERWRITE_VERBOSITY_FN_, 0);
@@ -2085,7 +2085,7 @@ void sc_simcontext::set_log_verbosity_fn(
   }
 }
 
-sc_log_level sc_simcontext::get_log_verbosity(sc_log_logger_cache &logger,
+sc_verbosity sc_simcontext::get_log_verbosity(sc_log_logger_cache &logger,
                                               const char *file,
                                               int line,
                                               std::string_view local_tag) {
@@ -2098,11 +2098,11 @@ sc_log_level sc_simcontext::get_log_verbosity(sc_log_logger_cache &logger,
 // NB these functions are NOT a standard API, but are
 // exposed to provide access to the (implementation defined) dynamic logging configuration
 void sc_log_impl::sc_set_log_verbosity_fn(
-    std::function<sc_log_level(sc_log_logger_cache &, const char *, int, std::string_view)> fn)
+    std::function<sc_verbosity(sc_log_logger_cache &, const char *, int, std::string_view)> fn)
 {
   sc_get_curr_simcontext()->set_log_verbosity_fn(std::move(fn));
 }
-sc_log_level sc_log_impl::sc_get_log_verbosity(sc_log_logger_cache &logger, const char *file,
+sc_verbosity sc_log_impl::sc_get_log_verbosity(sc_log_logger_cache &logger, const char *file,
                                   int line, std::string_view local_tag) {
   return sc_get_curr_simcontext()->get_log_verbosity(logger, file, line, local_tag);
 }

--- a/src/sysc/kernel/sc_simcontext.h
+++ b/src/sysc/kernel/sc_simcontext.h
@@ -155,7 +155,7 @@ struct sc_log_impl {
 // | logger cache and local_tag. The cache parameter may be used to remember
 // | a computed level, once set the function will not be re-called.
 // +------------------------------------------------------------------------------------------------
-static void sc_set_log_verbosity_fn(std::function<sc_core::sc_log_level(
+static void sc_set_log_verbosity_fn(std::function<sc_core::sc_verbosity(
                                  sc_core::sc_log_logger_cache &, const char *,
                                  int, std::string_view)>
                                  fn);
@@ -165,7 +165,7 @@ static void sc_set_log_verbosity_fn(std::function<sc_core::sc_log_level(
 // | If no callback has been installed, the implementation falls back to
 // | the global report verbosity.
 // +------------------------------------------------------------------------------------------------
-static sc_core::sc_log_level sc_get_log_verbosity(sc_core::sc_log_logger_cache &logger,
+static sc_core::sc_verbosity sc_get_log_verbosity(sc_core::sc_log_logger_cache &logger,
                                            const char *file, int line,
                                            std::string_view local_tag = {});
 };
@@ -356,11 +356,11 @@ public:
     void post_suspend() const;
 
 private:
-    void set_log_verbosity_fn(std::function<sc_core::sc_log_level(
+    void set_log_verbosity_fn(std::function<sc_core::sc_verbosity(
                                   sc_core::sc_log_logger_cache &, const char *,
                                   int, std::string_view)>
                                   fn);
-    sc_core::sc_log_level get_log_verbosity(
+    sc_core::sc_verbosity get_log_verbosity(
         sc_core::sc_log_logger_cache &,
         const char *file,
         int line,
@@ -415,7 +415,7 @@ private:
 
     inline void set_simulation_status(sc_status status);
 
-    std::function<sc_log_level(sc_log_logger_cache &, const char* , int, std::string_view)> dynamic_log_verbosity;
+    std::function<sc_verbosity(sc_log_logger_cache &, const char* , int, std::string_view)> dynamic_log_verbosity;
 
 private:
 

--- a/src/sysc/log/sc_log.cpp
+++ b/src/sysc/log/sc_log.cpp
@@ -28,26 +28,15 @@
 
 namespace sc_core {
 
-// Definition of log level map (declared as extern in sc_log_types.h)
-// This avoids creating duplicate copies in each translation unit.
-const std::map<sc_log_level, std::string> log_level_map = {
-    {sc_log_level::CRITICAL, "CRITICAL"},
-    {sc_log_level::NONE, "NONE"},
-    {sc_log_level::WARN, "WARN"},
-    {sc_log_level::INFO, "INFO"},
-    {sc_log_level::DEBUG, "DEBUG"},
-    {sc_log_level::TRACE, "TRACE"}
-};
-
 static thread_local sc_log_logger_cache* s_current = nullptr;
 
 sc_log_logger_cache* sc_log_logger_cache::get_current() { return s_current; }
 void sc_log_logger_cache::set_current(sc_log_logger_cache* p) { s_current = p; }
 
-sc_log_level sc_log_logger_cache::get_log_verbosity_cached(
+int sc_log_logger_cache::get_log_verbosity_cached(
     const char *file, int line, std::string_view local_tag) {
   s_current = this;
-  if (level != sc_log_level::UNSET) {
+  if (level != SC_UNSET) {
     return level;
   }
 
@@ -56,7 +45,7 @@ sc_log_level sc_log_logger_cache::get_log_verbosity_cached(
 
 void sc_log_logger_cache::set_tag(std::string new_tag) {
   tag = std::move(new_tag);
-  level = sc_log_level::UNSET;
+  level = SC_UNSET;
 }
 
 } // namespace sc_core
@@ -64,7 +53,7 @@ void sc_log_logger_cache::set_tag(std::string new_tag) {
 // Global default logger with empty tag (in global namespace for proper name
 // shadowing). This logger is used when no specific logger handle is provided.
 sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE{
-    sc_core::sc_log_level::UNSET,  // level
+    sc_core::SC_UNSET,  // level
     {},                             // tag (empty)
     {},                             // scname (empty)
     nullptr                         // typename_str (no type info)

--- a/src/sysc/log/sc_log.h
+++ b/src/sysc/log/sc_log.h
@@ -125,29 +125,29 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
 // Internal handle variants (used by public SC_LOG_HANDLE macro)
 #define SC_LOG_PRIV__HANDLE0()                                                 \
   sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE =                        \
-      sc_core::sc_log_handle_factory::make(sc_core::sc_log_level::UNSET, "",   \
+      sc_core::sc_log_handle_factory::make(sc_core::SC_UNSET, "",   \
                                            this)
 
 #define SC_LOG_PRIV__HANDLE1(tag_str)                                          \
   sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE =                        \
-      sc_core::sc_log_handle_factory::make(sc_core::sc_log_level::UNSET,       \
+      sc_core::sc_log_handle_factory::make(sc_core::SC_UNSET,       \
                                            tag_str, this)
 
 #define SC_LOG_PRIV__HANDLE2(logger_name, tag_str)                             \
   sc_core::sc_log_logger_cache SC_LOG_PRIV__HANDLE_NAME(logger_name) =         \
-      sc_core::sc_log_handle_factory::make(sc_core::sc_log_level::UNSET,       \
+      sc_core::sc_log_handle_factory::make(sc_core::SC_UNSET,       \
                                            tag_str, this)
 
 // Internal static handle variants (used by public SC_LOG_HANDLE_STATIC macro)
 #define SC_LOG_PRIV__HANDLE_STATIC1(tag_str)                                   \
   static sc_core::sc_log_logger_cache SC_LOG_LOG_LEVEL_CACHE =                 \
       sc_core::sc_log_handle_factory::make_static(                             \
-          sc_core::sc_log_level::UNSET, tag_str)
+          sc_core::SC_UNSET, tag_str)
 
 #define SC_LOG_PRIV__HANDLE_STATIC2(logger_name, tag_str)                      \
   static sc_core::sc_log_logger_cache SC_LOG_PRIV__HANDLE_NAME(logger_name) =  \
       sc_core::sc_log_handle_factory::make_static(                             \
-          sc_core::sc_log_level::UNSET, tag_str)
+          sc_core::SC_UNSET, tag_str)
 
 // Helper to get logger handle name
 #define SC_LOG_PRIV__HANDLE_NAME(x) x
@@ -195,15 +195,15 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
 #define SC_LOG_HANDLE_VECTOR_PUSH_BACK(NAME, tag_str)                          \
   SC_LOG_PRIV__HANDLE_NAME(NAME).push_back(                                    \
       sc_core::sc_log_handle_factory::make(                                    \
-          sc_core::sc_log_level::UNSET, tag_str, this))
+          sc_core::SC_UNSET, tag_str, this))
 
 /**
  * SC_LOG_AT - Log a message at a specific level
  *
  * Usage:
- *   SC_LOG_AT(sc_core::sc_log_level::INFO) << "message";
- *   SC_LOG_AT(sc_core::sc_log_level::INFO, my_logger) << "message";
- *   SC_LOG_AT(sc_core::sc_log_level::INFO, "tag") << "message";
+ *   SC_LOG_AT(sc_core::SC_HIGH) << "message";
+ *   SC_LOG_AT(sc_core::SC_HIGH, my_logger) << "message";
+ *   SC_LOG_AT(sc_core::SC_HIGH, "tag") << "message";
  */
 #define SC_LOG_AT(lvl, ...)                                                    \
   if (SC_LOG_PRIV__VBSTY_CHECK_IMPL(SC_LOG_PRIV__NARG(__VA_ARGS__), lvl,       \
@@ -214,18 +214,31 @@ static const char *SC_LOG_PRIV__FMT_EMPTY_STR = "";
       << SC_LOG_PRIV__FMT_EMPTY_STR
 
 /**
- * Convenience macros for common log levels
+ * Convenience logging macros, one per logging level.
+ *
+ * The level names describe the *significance* (importance) of a message to a
+ * reader, deliberately chosen to be distinct from SystemC's existing
+ * vocabularies — they are NOT sc_severity (SC_INFO/SC_WARNING/SC_ERROR/
+ * SC_FATAL) and NOT the raw sc_verbosity names. Ordered from most significant
+ * to least, mapping onto increasing verbosity: the more verbose the level, the
+ * less significant (more incidental) the message.
+ *
+ *   SC_CRITICAL  most significant   -> SC_LOW    (emitted even at low verbosity)
+ *   SC_ALERT                        -> SC_MEDIUM
+ *   SC_NOTE                         -> SC_HIGH
+ *   SC_DETAIL                       -> SC_FULL
+ *   SC_INTERNAL  least significant  -> SC_DEBUG  (only at the highest verbosity)
  *
  * Usage:
  *   SC_CRITICAL() << "message";
- *   SC_WARN(my_logger) << "message";
- *   SC_INFO("tag") << "message";
+ *   SC_ALERT(my_logger) << "message";
+ *   SC_NOTE("tag") << "message";
  */
 #define SC_CRITICAL(...)                                                       \
-  SC_LOG_AT(sc_core::sc_log_level::CRITICAL, ##__VA_ARGS__)
-#define SC_WARN(...) SC_LOG_AT(sc_core::sc_log_level::WARN, ##__VA_ARGS__)
-#define SC_INFO(...) SC_LOG_AT(sc_core::sc_log_level::INFO, ##__VA_ARGS__)
-#define SC_DEBUG(...) SC_LOG_AT(sc_core::sc_log_level::DEBUG, ##__VA_ARGS__)
-#define SC_TRACE(...) SC_LOG_AT(sc_core::sc_log_level::TRACE, ##__VA_ARGS__)
+  SC_LOG_AT(sc_core::SC_LOW, ##__VA_ARGS__)
+#define SC_ALERT(...) SC_LOG_AT(sc_core::SC_MEDIUM, ##__VA_ARGS__)
+#define SC_NOTE(...) SC_LOG_AT(sc_core::SC_HIGH, ##__VA_ARGS__)
+#define SC_DETAIL(...) SC_LOG_AT(sc_core::SC_FULL, ##__VA_ARGS__)
+#define SC_INTERNAL(...) SC_LOG_AT(sc_core::SC_DEBUG, ##__VA_ARGS__)
 
 #endif /* _SC_LOG_H_ */

--- a/src/sysc/log/sc_log_types.h
+++ b/src/sysc/log/sc_log_types.h
@@ -45,82 +45,37 @@
 namespace sc_core {
 
 /************************
- * Provide a set of names and conversions that are suitable for logging levels
- *based on SystemC "verbosity's"
+ * Logging levels are expressed directly as sc_core::sc_verbosity values:
+ *   SC_LOW (100)=CRITICAL  SC_MEDIUM (200)=ALERT  SC_HIGH (300)=NOTE
+ *   SC_FULL (400)=DETAIL   SC_DEBUG (500)=INTERNAL.  SC_NONE (0) is "off".
+ *
+ * A logging level is carried as a plain int (SC_LOG_AT accepts any
+ * user-defined level), so the logger cache stores an int and uses the
+ * sentinel below for "not yet resolved / inherit from context".
  ************************/
 
-enum class sc_log_level {
-  NONE = sc_core::SC_NONE,
-  CRITICAL = sc_core::SC_NONE,
-  WARN = sc_core::SC_LOW,
-  INFO = sc_core::SC_MEDIUM,
-  DEBUG = sc_core::SC_HIGH,
-  TRACE = sc_core::SC_DEBUG,
-
-  UNSET = INT_MAX
-};
-
-// Map of log levels to their string representations (defined in sc_log.cpp)
-extern const std::map<sc_log_level, std::string> log_level_map;
+// "Level not yet resolved" sentinel for the logger cache.  This is an
+// internal implementation marker (NOT part of the IEEE 1666 standard) and a
+// plain int — deliberately NOT an sc_verbosity enumerator — so it never
+// appears in the standardized sc_verbosity enum.
+inline constexpr int SC_UNSET = INT_MAX;
 
 /**
- * @fn log as_log(int)
- * @brief safely convert an integer into a log level
+ * @fn sc_verbosity as_log(int)
+ * @brief bucket a raw verbosity to the nearest level at or above it
  *
- * @param logLevel the logging level
- * @return the log level
- */
-inline sc_log_level as_log(int logLevel) {
-  auto m = log_level_map;
-  for (auto l : m) {
-    if (logLevel <= static_cast<int>(l.first)) {
-      return l.first;
-    }
-  }
-  return sc_log_level::TRACE;
-}
-
-/**
- * @fn log as_log(std::string)
- * @brief safely convert a string into a log level
+ * v <= 100 -> CRITICAL, <= 200 -> ALERT, <= 300 -> NOTE,
+ * <= 400 -> DETAIL, otherwise INTERNAL.
  *
- * @param logName the string name for the log level
- * @return the log level
+ * @param logLevel the raw verbosity
+ * @return the bucketed log level
  */
-inline sc_log_level as_log(std::string logName) {
-  auto m = log_level_map;
-  for (auto l : m) {
-    if (logName == l.second)
-      return l.first;
-  }
-  return sc_log_level::TRACE;
-}
-/**
- * @fn std::istream& operator >>(std::istream&, log&)
- * @brief read a log level from input stream e.g. used by boost::lexical_cast
- *
- * @param is input stream holding the string representation
- * @param val the value holding the resulting value
- * @return the input stream
- */
-inline std::istream &operator>>(std::istream &is, sc_log_level &val) {
-  std::string buf;
-  is >> buf;
-  val = as_log(buf);
-  return is;
-}
-/**
- * @fn std::ostream& operator <<(std::ostream&, const log&)
- * @brief output the textual representation of the log level
- *
- * @param os output stream
- * @param val logging level
- * @return reference to the stream for chaining
- */
-inline std::ostream &operator<<(std::ostream &os, sc_log_level const &val) {
-  auto m = log_level_map;
-  os << m[val];
-  return os;
+inline sc_verbosity as_log(int logLevel) {
+  if (logLevel <= sc_core::SC_LOW)    return sc_core::SC_LOW;
+  if (logLevel <= sc_core::SC_MEDIUM) return sc_core::SC_MEDIUM;
+  if (logLevel <= sc_core::SC_HIGH)   return sc_core::SC_HIGH;
+  if (logLevel <= sc_core::SC_FULL)   return sc_core::SC_FULL;
+  return sc_core::SC_DEBUG;
 }
 
 /* Convenience helper to detect if a type has a name() method.
@@ -168,7 +123,7 @@ struct sc_log_impl;
  * since all referenced strings have appropriate lifetimes.
  */
 struct sc_log_logger_cache {
-  sc_log_level level = sc_log_level::UNSET;
+  int level = SC_UNSET;
   std::string tag{};           // Logger tag/identifier (owns the string)
   std::string scname{};        // Captured sc_object name (owns the string)
   const char* typename_str = nullptr; // Captured type name (from typeid(*this).name())
@@ -184,7 +139,7 @@ struct sc_log_logger_cache {
    * @param local_tag optional local tag that overrides the effective name
    * @return log level for this logger
    */
-  sc_log_level get_log_verbosity_cached(const char *file, int line,
+  int get_log_verbosity_cached(const char *file, int line,
                                         std::string_view local_tag = {});
 
   /**
@@ -220,7 +175,7 @@ struct sc_log_logger_cache {
  */
 struct sc_log_handle_factory {
   template <class TYPE>
-  static sc_log_logger_cache make(sc_log_level lvl, const char *tag_str,
+  static sc_log_logger_cache make(int lvl, const char *tag_str,
                                   TYPE *p) {
     const char *n = sc_log_priv__call_sc_name_fn{}(p);
     const char *t = typeid(*p).name();
@@ -232,7 +187,7 @@ struct sc_log_handle_factory {
     };
   }
 
-  static sc_log_logger_cache make_static(sc_log_level lvl,
+  static sc_log_logger_cache make_static(int lvl,
                                          const char *tag_str) {
     return sc_log_logger_cache{
         lvl,
@@ -269,7 +224,7 @@ struct sc_logger {
    * @param verbosity the log level
    */
   sc_logger(const char *file, int line,
-            sc_log_level verbosity = sc_core::sc_log_level::INFO)
+            int verbosity = sc_core::SC_MEDIUM)
       : t(nullptr), file(file), line(line), level(verbosity) {}
 
 
@@ -348,7 +303,7 @@ protected:
   char *t{nullptr};
   const char *file;
   const int line;
-  const sc_log_level level;
+  const int level;
 };
 
 } // namespace sc_core

--- a/src/sysc/utils/sc_report.h
+++ b/src/sysc/utils/sc_report.h
@@ -34,6 +34,7 @@
 #ifndef SC_REPORT_H
 #define SC_REPORT_H 1
 
+#include <climits>
 #include <exception>
 #include <string>
 #include "sysc/kernel/sc_cmnhdr.h"
@@ -65,7 +66,10 @@ enum sc_severity {
 //  Enumeration of message verbosity.
 // ----------------------------------------------------------------------------
 
- enum sc_verbosity {
+ // The underlying type is fixed to int so that an arbitrary integer logging
+ // level (SC_LOG_AT accepts any user-defined level) converts to/from
+ // sc_verbosity with a well-defined value, even outside the named range.
+ enum sc_verbosity : int {
      SC_NONE = 0,
      SC_LOW = 100,
      SC_MEDIUM = 200,

--- a/tests/systemc/sc_log/test01/golden/test01.log
+++ b/tests/systemc/sc_log/test01/golden/test01.log
@@ -1,48 +1,48 @@
 SystemC Simulation
-TEST REPORT: DEBUG : [sc_main] Global Warning from sc_main line:221
-TEST REPORT: WARN : [quiet] Global Warning from sc_main line:222
-TEST REPORT: WARN : [GlobalLogger] My Global Warn from sc_main line:224
+TEST REPORT: DETAIL : [sc_main] Global Warning from sc_main line:234
+TEST REPORT: ALERT : [quiet] Global Warning from sc_main line:235
+TEST REPORT: ALERT : [GlobalLogger] My Global Warn from sc_main line:237
 0 is log_level CRITICAL
-50 is log_level WARN
-100 is log_level WARN
-150 is log_level INFO
-200 is log_level INFO
-250 is log_level DEBUG
-300 is log_level DEBUG
-350 is log_level TRACE
-400 is log_level TRACE
-450 is log_level TRACE
+50 is log_level CRITICAL
+100 is log_level CRITICAL
+150 is log_level ALERT
+200 is log_level ALERT
+250 is log_level NOTE
+300 is log_level NOTE
+350 is log_level DETAIL
+400 is log_level DETAIL
+450 is log_level INTERNAL
 Test string based handler
-TEST REPORT: CRITICAL : [sc_log_test] CRITICAL line:233
-TEST REPORT: WARN : [sc_log_test] WARN line:233
+TEST REPORT: CRITICAL : [sc_log_test] CRITICAL line:246
+TEST REPORT: ALERT : [sc_log_test] ALERT line:246
 test FMT string
-TEST REPORT: WARN : [SystemC] Testing FMT Hello world line:237
+TEST REPORT: ALERT : [SystemC] Testing FMT Hello world line:250
 construct module
-TEST REPORT: WARN : [MyMod] HERE line:49
-TEST REPORT: WARN : [GlobalLogger] Global Warning line:50
-TEST REPORT: CRITICAL : [MyMod]  Log to name() (at level CRITICAL) line:53
-TEST REPORT: CRITICAL : [My Tag]  Log to My Tag (at level CRITICAL) line:54
-TEST REPORT: CRITICAL : [MyMod]  Log to default () (at level CRITICAL) line:55
-TEST REPORT: CRITICAL : [test_handler]  Log to test_handler (at level CRITICAL) line:56
-TEST REPORT: CRITICAL : [My TST Tag]  Log using () to My TH Tag (at level CRITICAL) line:57
-TEST REPORT: WARN : [MyMod]  Log to name() (at level WARN) line:53
-TEST REPORT: WARN : [My Tag]  Log to My Tag (at level WARN) line:54
-TEST REPORT: WARN : [MyMod]  Log to default () (at level WARN) line:55
-TEST REPORT: WARN : [test_handler]  Log to test_handler (at level WARN) line:56
-TEST REPORT: WARN : [My TST Tag]  Log using () to My TH Tag (at level WARN) line:57
-TEST REPORT: INFO : [MyMod]  Log to name() (at level INFO) line:53
-TEST REPORT: INFO : [My Tag]  Log to My Tag (at level INFO) line:54
-TEST REPORT: INFO : [MyMod]  Log to default () (at level INFO) line:55
-TEST REPORT: INFO : [test_handler]  Log to test_handler (at level INFO) line:56
-TEST REPORT: INFO : [My TST Tag]  Log using () to My TH Tag (at level INFO) line:57
-TEST REPORT: DEBUG : [MyMod]  Log to name() (at level DEBUG) line:53
-TEST REPORT: DEBUG : [My Tag]  Log to My Tag (at level DEBUG) line:54
-TEST REPORT: DEBUG : [MyMod]  Log to default () (at level DEBUG) line:55
-TEST REPORT: TRACE : [MyMod]  Log to name() (at level TRACE) line:53
-TEST REPORT: TRACE : [My Tag]  Log to My Tag (at level TRACE) line:54
-TEST REPORT: TRACE : [MyMod]  Log to default () (at level TRACE) line:55
-TEST REPORT: CRITICAL : [MyMod] SC_CRITICAL line:61
-TEST REPORT: WARN : [MyMod] SC_WARN line:62
-TEST REPORT: INFO : [MyMod] SC_INFO line:63
-TEST REPORT: DEBUG : [MyMod] SC_DEBUG line:64
-TEST REPORT: TRACE : [MyMod] SC_TRACE line:65
+TEST REPORT: ALERT : [MyMod] HERE line:62
+TEST REPORT: ALERT : [GlobalLogger] Global Warning line:63
+TEST REPORT: CRITICAL : [MyMod]  Log to name() (at level 100) line:66
+TEST REPORT: CRITICAL : [My Tag]  Log to My Tag (at level 100) line:67
+TEST REPORT: CRITICAL : [MyMod]  Log to default () (at level 100) line:68
+TEST REPORT: CRITICAL : [test_handler]  Log to test_handler (at level 100) line:69
+TEST REPORT: CRITICAL : [My TST Tag]  Log using () to My TH Tag (at level 100) line:70
+TEST REPORT: ALERT : [MyMod]  Log to name() (at level 200) line:66
+TEST REPORT: ALERT : [My Tag]  Log to My Tag (at level 200) line:67
+TEST REPORT: ALERT : [MyMod]  Log to default () (at level 200) line:68
+TEST REPORT: ALERT : [test_handler]  Log to test_handler (at level 200) line:69
+TEST REPORT: ALERT : [My TST Tag]  Log using () to My TH Tag (at level 200) line:70
+TEST REPORT: NOTE : [MyMod]  Log to name() (at level 300) line:66
+TEST REPORT: NOTE : [My Tag]  Log to My Tag (at level 300) line:67
+TEST REPORT: NOTE : [MyMod]  Log to default () (at level 300) line:68
+TEST REPORT: NOTE : [test_handler]  Log to test_handler (at level 300) line:69
+TEST REPORT: NOTE : [My TST Tag]  Log using () to My TH Tag (at level 300) line:70
+TEST REPORT: DETAIL : [MyMod]  Log to name() (at level 400) line:66
+TEST REPORT: DETAIL : [My Tag]  Log to My Tag (at level 400) line:67
+TEST REPORT: DETAIL : [MyMod]  Log to default () (at level 400) line:68
+TEST REPORT: INTERNAL : [MyMod]  Log to name() (at level 500) line:66
+TEST REPORT: INTERNAL : [My Tag]  Log to My Tag (at level 500) line:67
+TEST REPORT: INTERNAL : [MyMod]  Log to default () (at level 500) line:68
+TEST REPORT: CRITICAL : [MyMod] SC_CRITICAL line:74
+TEST REPORT: ALERT : [MyMod] SC_ALERT line:75
+TEST REPORT: NOTE : [MyMod] SC_NOTE line:76
+TEST REPORT: DETAIL : [MyMod] SC_DETAIL line:77
+TEST REPORT: INTERNAL : [MyMod] SC_INTERNAL line:78

--- a/tests/systemc/sc_log/test01/test01.cpp
+++ b/tests/systemc/sc_log/test01/test01.cpp
@@ -38,17 +38,30 @@
 #include "systemc.h"
 #include <functional>
 #include <iostream>
+#include <map>
+#include <string>
 #include <string_view>
 #include <unordered_set>
+
+// Core no longer ships a level<->name map (textual names are an SCP
+// convenience).  Tests that print level names keep their own local map.
+static const std::map<sc_core::sc_verbosity, std::string> k_level_names = {
+    {sc_core::SC_LOW, "CRITICAL"}, {sc_core::SC_MEDIUM, "ALERT"},
+    {sc_core::SC_HIGH, "NOTE"},    {sc_core::SC_FULL, "DETAIL"},
+    {sc_core::SC_DEBUG, "INTERNAL"}};
+static std::string level_name(sc_core::sc_verbosity v) {
+  auto it = k_level_names.find(v);
+  return it == k_level_names.end() ? std::string("NONE") : it->second;
+}
 
 SC_LOG_HANDLE_STATIC(MY_GLOBAL_LOGGER, "GlobalLogger");
 
 SC_MODULE(mod_a) {
   SC_LOG_HANDLE(TST, "test_handler");
   SC_CTOR(mod_a) {
-    SC_WARN() << "HERE";
-    SC_WARN(MY_GLOBAL_LOGGER)("Global Warning");
-    for (auto l : sc_core::log_level_map) {
+    SC_ALERT() << "HERE";
+    SC_ALERT(MY_GLOBAL_LOGGER)("Global Warning");
+    for (auto l : k_level_names) {
       auto i = l.first;
       SC_LOG_AT(i, name()) << " Log to name()" << " (at level " << i << ")";
       SC_LOG_AT(i, "My Tag") << " Log to My Tag" << " (at level " << i << ")";
@@ -59,10 +72,10 @@ SC_MODULE(mod_a) {
     }
 
     SC_CRITICAL() << "SC_CRITICAL";
-    SC_WARN() << "SC_WARN";
-    SC_INFO() << "SC_INFO";
-    SC_DEBUG() << "SC_DEBUG";
-    SC_TRACE() << "SC_TRACE";
+    SC_ALERT() << "SC_ALERT";
+    SC_NOTE() << "SC_NOTE";
+    SC_DETAIL() << "SC_DETAIL";
+    SC_INTERNAL() << "SC_INTERNAL";
   }
 };
 
@@ -85,7 +98,7 @@ SC_MODULE(mod_a) {
  *
  * void sc_set_log_verbosity_fn(
  *     std::function<
- *         sc_core::sc_log_level(
+ *         sc_core::sc_verbosity(
  *            sc_core::sc_log_logger_cache &logger,
  *            const char *file,
  *            int line,
@@ -104,7 +117,7 @@ SC_MODULE(mod_a) {
  * will fall back to the global report verbosity.
  * --------------------------------------------------------
  *
- * sc_core::sc_log_level sc_log_impl::sc_get_log_verbosity(
+ * sc_core::sc_verbosity sc_log_impl::sc_get_log_verbosity(
  *     sc_core::sc_log_logger_cache &logger,
  *     const char *file,
  *     int line,
@@ -129,7 +142,7 @@ SC_MODULE(mod_a) {
 
 class scp_logger_test {
 
-  std::unordered_map<uint64_t, sc_core::sc_log_level> lut;
+  std::unordered_map<uint64_t, sc_core::sc_verbosity> lut;
 
   // BKDR hash algorithm
   auto char_hash(std::string_view str) -> uint64_t {
@@ -142,7 +155,7 @@ class scp_logger_test {
   }
 
   std::unordered_set<sc_core::sc_log_logger_cache *> loggers;
-  sc_core::sc_log_level operator()(struct sc_core::sc_log_logger_cache &logger,
+  sc_core::sc_verbosity operator()(struct sc_core::sc_log_logger_cache &logger,
                                    const char *file, int line,
                                    std::string_view local_tag) {
     loggers.insert(&logger);
@@ -159,36 +172,36 @@ class scp_logger_test {
         return it->second;
       }
 
-      sc_core::sc_log_level lvl = sc_core::sc_log_level::TRACE;
+      sc_core::sc_verbosity lvl = sc_core::SC_DEBUG;
       if (local_tag == "quiet")
-        lvl = sc_core::sc_log_level::WARN;
+        lvl = sc_core::SC_MEDIUM;
       if (local_tag == "sc_main")
-        lvl = sc_core::sc_log_level::DEBUG;
+        lvl = sc_core::SC_FULL;
       if (local_tag == "sc_log_test")
-        lvl = sc_core::sc_log_level::WARN;
+        lvl = sc_core::SC_MEDIUM;
 
       lut[k] = lvl;
       return lvl;
     }
 
     if (logger.tag == "test_handler") {
-      return sc_core::sc_log_level::INFO;
+      return sc_core::SC_HIGH;
     }
     if (logger.tag == "GlobalLogger") {
-      return sc_core::sc_log_level::WARN;
+      return sc_core::SC_MEDIUM;
     }
     /* Cache this one which will catch the normal SCMOD case for mod_a */
-    logger.level = sc_core::sc_log_level::TRACE;
-    return sc_core::sc_log_level::TRACE;
+    logger.level = sc_core::SC_DEBUG;
+    return sc_core::SC_DEBUG;
   }
 
 public:
   scp_logger_test() {
-    std::function<sc_core::sc_log_level(sc_core::sc_log_logger_cache &,
+    std::function<sc_core::sc_verbosity(sc_core::sc_log_logger_cache &,
                                         const char *, int, std::string_view)>
         fn = [&](sc_core::sc_log_logger_cache &logger, const char *file,
                  int line,
-                 std::string_view local_tag) -> sc_core::sc_log_level {
+                 std::string_view local_tag) -> sc_core::sc_verbosity {
       return operator()(logger, file, line, local_tag);
     };
     ::sc_core::sc_log_impl::sc_set_log_verbosity_fn(fn);
@@ -199,7 +212,7 @@ public:
   void reset() {
     for (auto *logger : loggers) {
       if (logger) {
-        logger->level = sc_core::sc_log_level::UNSET;
+        logger->level = sc_core::SC_UNSET;
       }
     }
   }
@@ -209,7 +222,7 @@ static scp_logger_test test_logger_handler;
 
 void report_handler(const sc_core::sc_report &rep,
                     const sc_core::sc_actions &actions) {
-  cout << "TEST REPORT: " << sc_core::as_log(rep.get_verbosity()) << " : ["
+  cout << "TEST REPORT: " << level_name(sc_core::as_log(rep.get_verbosity())) << " : ["
        << rep.get_msg_type() << "] " << rep.get_msg()
        << " line:" << rep.get_line_number() << std::endl;
 }
@@ -218,23 +231,23 @@ int sc_main(int, char *[]) {
   ::sc_core::sc_report_handler::set_verbosity_level(sc_core::SC_DEBUG);
   ::sc_core::sc_report_handler::set_handler(report_handler);
 
-  SC_DEBUG("sc_main")("Global Warning from sc_main");
-  SC_WARN("quiet")("Global Warning from sc_main");
-  SC_INFO("quiet")("Global Warning from sc_main (** filtered out **)");
-  SC_WARN(MY_GLOBAL_LOGGER)("My Global Warn from sc_main");
-  SC_DEBUG(MY_GLOBAL_LOGGER,
+  SC_DETAIL("sc_main")("Global Warning from sc_main");
+  SC_ALERT("quiet")("Global Warning from sc_main");
+  SC_NOTE("quiet")("Global Warning from sc_main (** filtered out **)");
+  SC_ALERT(MY_GLOBAL_LOGGER)("My Global Warn from sc_main");
+  SC_DETAIL(MY_GLOBAL_LOGGER,
            "sc_main")("Global Debug from sc_main (** filtered out **)");
 
   for (int i = 0; i < 500; i += 50) {
-    cout << i << " is log_level " << sc_core::as_log(i) << endl;
+    cout << i << " is log_level " << level_name(sc_core::as_log(i)) << endl;
   }
   cout << "Test string based handler" << std::endl;
-  for (auto l : sc_core::log_level_map) {
+  for (auto l : k_level_names) {
     SC_LOG_AT(l.first, "sc_log_test") << l.second;
   }
 
   cout << "test FMT string" << std::endl;
-  SC_WARN()("Testing FMT Hello {}", "world");
+  SC_ALERT()("Testing FMT Hello {}", "world");
 
   cout << "construct module" << std::endl;
 

--- a/tests/systemc/sc_log/test02/golden/test02.log
+++ b/tests/systemc/sc_log/test02/golden/test02.log
@@ -4,77 +4,77 @@ SC_LOG API Comprehensive Test (test02)
 ========================================
 
 === Test Global Static Loggers ===
-[INFO] SystemC: INFO: Global default logger (no tag)
-[WARN] SystemC: WARN: Global default logger, format: test
-[INFO] GlobalTag: INFO: Global logger with tag
+[NOTE] SystemC: NOTE: Global default logger (no tag)
+[ALERT] SystemC: ALERT: Global default logger, format: test
+[NOTE] GlobalTag: NOTE: Global logger with tag
 
 === Test Tag-Based Logging ===
-[INFO] Tag1: INFO: Using Tag1
-[WARN] Tag2: WARN: Using Tag2 with format: value
-[DEBUG] Tag3: DEBUG: Using Tag3
-[TRACE] Tag4: TRACE: Using Tag4 with format: 999
+[NOTE] Tag1: NOTE: Using Tag1
+[ALERT] Tag2: ALERT: Using Tag2 with format: value
+[DETAIL] Tag3: DETAIL: Using Tag3
+[INTERNAL] Tag4: INTERNAL: Using Tag4 with format: 999
 
 === Test All Log Levels ===
 [CRITICAL] LevelTest: CRITICAL level test
-[WARN] LevelTest: WARN level test
-[INFO] LevelTest: INFO level test
-[DEBUG] LevelTest: DEBUG level test
-[TRACE] LevelTest: TRACE level test
+[ALERT] LevelTest: ALERT level test
+[NOTE] LevelTest: NOTE level test
+[DETAIL] LevelTest: DETAIL level test
+[INTERNAL] LevelTest: INTERNAL level test
 [CRITICAL] LevelTest: CRITICAL level test with format: 1
-[WARN] LevelTest: WARN level test with format: 2
-[INFO] LevelTest: INFO level test with format: 3
-[DEBUG] LevelTest: DEBUG level test with format: 4
-[TRACE] LevelTest: TRACE level test with format: 5
+[ALERT] LevelTest: ALERT level test with format: 2
+[NOTE] LevelTest: NOTE level test with format: 3
+[DETAIL] LevelTest: DETAIL level test with format: 4
+[INTERNAL] LevelTest: INTERNAL level test with format: 5
 
 === Test Complex Format Strings ===
-[INFO] FormatTest: Multiple args: 1, 2, 3
-[INFO] FormatTest: Mixed types: int=42, str=hello, float=3.14
-[INFO] FormatTest: Nested braces: {} and value: 123
-[INFO] FormatTest: Empty format string
+[NOTE] FormatTest: Multiple args: 1, 2, 3
+[NOTE] FormatTest: Mixed types: int=42, str=hello, float=3.14
+[NOTE] FormatTest: Nested braces: {} and value: 123
+[NOTE] FormatTest: Empty format string
 
 === Test Module with Default Logger ===
 [CRITICAL] mod_default: CRITICAL: Default logger, stream syntax
-[WARN] mod_default: WARN: Default logger, stream syntax
-[INFO] mod_default: INFO: Default logger, stream syntax
-[DEBUG] mod_default: DEBUG: Default logger, stream syntax
-[TRACE] mod_default: TRACE: Default logger, stream syntax
-[WARN] mod_default: WARN: Default logger, format syntax with arg: 42
-[INFO] mod_default: INFO: Default logger, format syntax with multiple args: hello world
+[ALERT] mod_default: ALERT: Default logger, stream syntax
+[NOTE] mod_default: NOTE: Default logger, stream syntax
+[DETAIL] mod_default: DETAIL: Default logger, stream syntax
+[INTERNAL] mod_default: INTERNAL: Default logger, stream syntax
+[ALERT] mod_default: ALERT: Default logger, format syntax with arg: 42
+[NOTE] mod_default: NOTE: Default logger, format syntax with multiple args: hello world
 
 === Test Module with Tagged Logger ===
 [CRITICAL] ModuleTag: CRITICAL: Tagged logger
-[WARN] ModuleTag: WARN: Tagged logger
-[INFO] ModuleTag: INFO: Tagged logger
-[DEBUG] ModuleTag: DEBUG: Tagged logger
-[INFO] ModuleTag: INFO: Tagged logger with format: 123
+[ALERT] ModuleTag: ALERT: Tagged logger
+[NOTE] ModuleTag: NOTE: Tagged logger
+[DETAIL] ModuleTag: DETAIL: Tagged logger
+[NOTE] ModuleTag: NOTE: Tagged logger with format: 123
 
 === Test Module with Multiple Named Loggers ===
-[WARN] Logger1Tag: WARN: Using logger1 with format: test
-[INFO] Logger2Tag: INFO: Using logger2
-[DEBUG] Logger2Tag: DEBUG: Using logger2 with format: 456
-[INFO] mod_multi: INFO: Using default logger
-[TRACE] mod_multi: TRACE: Using default logger with format
+[ALERT] Logger1Tag: ALERT: Using logger1 with format: test
+[NOTE] Logger2Tag: NOTE: Using logger2
+[DETAIL] Logger2Tag: DETAIL: Using logger2 with format: 456
+[NOTE] mod_multi: NOTE: Using default logger
+[INTERNAL] mod_multi: INTERNAL: Using default logger with format
 
 === Test Module with Vector of Loggers ===
-[INFO] VecLogger0: INFO: Vector logger 0
-[WARN] VecLogger0: WARN: Vector logger 0 with format
-[WARN] VecLogger1: WARN: Vector logger 1 with format
-[INFO] VecLogger2: INFO: Vector logger 2
-[WARN] VecLogger2: WARN: Vector logger 2 with format
+[NOTE] VecLogger0: NOTE: Vector logger 0
+[ALERT] VecLogger0: ALERT: Vector logger 0 with format
+[ALERT] VecLogger1: ALERT: Vector logger 1 with format
+[NOTE] VecLogger2: NOTE: Vector logger 2
+[ALERT] VecLogger2: ALERT: Vector logger 2 with format
 
 === Test SC_LOG_AT Variants ===
-[INFO] mod_log_at: SC_LOG_AT: No args, stream syntax
-[WARN] mod_log_at: SC_LOG_AT: No args, format syntax: 1
-[INFO] LogAtTag: SC_LOG_AT: With logger handle
-[DEBUG] LogAtTag: SC_LOG_AT: With logger handle, format: 2
-[INFO] ExplicitTag: SC_LOG_AT: With explicit tag
-[TRACE] ExplicitTag: SC_LOG_AT: With explicit tag, format: 3
-[WARN] OverrideTag: SC_LOG_AT: Logger + override tag
-[INFO] OverrideTag: SC_LOG_AT: Logger + override tag, format: 4
+[NOTE] mod_log_at: SC_LOG_AT: No args, stream syntax
+[ALERT] mod_log_at: SC_LOG_AT: No args, format syntax: 1
+[NOTE] LogAtTag: SC_LOG_AT: With logger handle
+[DETAIL] LogAtTag: SC_LOG_AT: With logger handle, format: 2
+[NOTE] ExplicitTag: SC_LOG_AT: With explicit tag
+[INTERNAL] ExplicitTag: SC_LOG_AT: With explicit tag, format: 3
+[ALERT] OverrideTag: SC_LOG_AT: Logger + override tag
+[NOTE] OverrideTag: SC_LOG_AT: Logger + override tag, format: 4
 
 === Test Using name() as Tag ===
-[INFO] mod_name_tag: Using name() as tag
-[WARN] mod_name_tag: Using name() as tag with format: mod_name_tag
+[NOTE] mod_name_tag: Using name() as tag
+[ALERT] mod_name_tag: Using name() as tag with format: mod_name_tag
 
 ========================================
 All tests completed successfully!

--- a/tests/systemc/sc_log/test02/test02.cpp
+++ b/tests/systemc/sc_log/test02/test02.cpp
@@ -36,7 +36,19 @@
 
 #include "systemc.h"
 #include <iostream>
+#include <map>
 #include <string>
+
+// Core no longer ships a level<->name map (textual names are an SCP
+// convenience).  Tests that print level names keep their own local map.
+static const std::map<sc_core::sc_verbosity, std::string> k_level_names = {
+    {sc_core::SC_LOW, "CRITICAL"}, {sc_core::SC_MEDIUM, "ALERT"},
+    {sc_core::SC_HIGH, "NOTE"},    {sc_core::SC_FULL, "DETAIL"},
+    {sc_core::SC_DEBUG, "INTERNAL"}};
+static std::string level_name(sc_core::sc_verbosity v) {
+  auto it = k_level_names.find(v);
+  return it == k_level_names.end() ? std::string("NONE") : it->second;
+}
 
 // Test 1: Global static logger handle with tag
 // Note: The default global SC_LOG_LOG_LEVEL_CACHE is already declared in sc_log.h
@@ -51,14 +63,14 @@ SC_MODULE(test_module_default) {
     
     // Test all log levels with stream syntax
     SC_CRITICAL() << "CRITICAL: Default logger, stream syntax";
-    SC_WARN() << "WARN: Default logger, stream syntax";
-    SC_INFO() << "INFO: Default logger, stream syntax";
-    SC_DEBUG() << "DEBUG: Default logger, stream syntax";
-    SC_TRACE() << "TRACE: Default logger, stream syntax";
+    SC_ALERT() << "ALERT: Default logger, stream syntax";
+    SC_NOTE() << "NOTE: Default logger, stream syntax";
+    SC_DETAIL() << "DETAIL: Default logger, stream syntax";
+    SC_INTERNAL() << "INTERNAL: Default logger, stream syntax";
     
     // Test format string syntax
-    SC_WARN()("WARN: Default logger, format syntax with arg: {}", 42);
-    SC_INFO()("INFO: Default logger, format syntax with multiple args: {} {}", "hello", "world");
+    SC_ALERT()("ALERT: Default logger, format syntax with arg: {}", 42);
+    SC_NOTE()("NOTE: Default logger, format syntax with multiple args: {} {}", "hello", "world");
   }
 };
 
@@ -70,12 +82,12 @@ SC_MODULE(test_module_tagged) {
     cout << "\n=== Test Module with Tagged Logger ===" << endl;
     
     SC_CRITICAL() << "CRITICAL: Tagged logger";
-    SC_WARN() << "WARN: Tagged logger";
-    SC_INFO() << "INFO: Tagged logger";
-    SC_DEBUG() << "DEBUG: Tagged logger";
-    SC_TRACE() << "TRACE: Tagged logger";
+    SC_ALERT() << "ALERT: Tagged logger";
+    SC_NOTE() << "NOTE: Tagged logger";
+    SC_DETAIL() << "DETAIL: Tagged logger";
+    SC_INTERNAL() << "INTERNAL: Tagged logger";
     
-    SC_INFO()("INFO: Tagged logger with format: {}", 123);
+    SC_NOTE()("NOTE: Tagged logger with format: {}", 123);
   }
 };
 
@@ -89,16 +101,16 @@ SC_MODULE(test_module_multi_logger) {
     cout << "\n=== Test Module with Multiple Named Loggers ===" << endl;
     
     // Test logger1
-    SC_INFO(logger1) << "INFO: Using logger1";
-    SC_WARN(logger1)("WARN: Using logger1 with format: {}", "test");
+    SC_NOTE(logger1) << "NOTE: Using logger1";
+    SC_ALERT(logger1)("ALERT: Using logger1 with format: {}", "test");
     
     // Test logger2
-    SC_INFO(logger2) << "INFO: Using logger2";
-    SC_DEBUG(logger2)("DEBUG: Using logger2 with format: {}", 456);
+    SC_NOTE(logger2) << "NOTE: Using logger2";
+    SC_DETAIL(logger2)("DETAIL: Using logger2 with format: {}", 456);
     
     // Test default logger
-    SC_INFO() << "INFO: Using default logger";
-    SC_TRACE()("TRACE: Using default logger with format");
+    SC_NOTE() << "NOTE: Using default logger";
+    SC_INTERNAL()("INTERNAL: Using default logger with format");
   }
 };
 
@@ -116,8 +128,8 @@ SC_MODULE(test_module_vector) {
     
     // Use loggers from vector
     for (size_t i = 0; i < logger_vec.size(); i++) {
-      SC_INFO(logger_vec[i]) << "INFO: Vector logger " << i;
-      SC_WARN(logger_vec[i])("WARN: Vector logger {} with format", i);
+      SC_NOTE(logger_vec[i]) << "NOTE: Vector logger " << i;
+      SC_ALERT(logger_vec[i])("ALERT: Vector logger {} with format", i);
     }
   }
 };
@@ -130,20 +142,20 @@ SC_MODULE(test_module_log_at) {
     cout << "\n=== Test SC_LOG_AT Variants ===" << endl;
     
     // SC_LOG_AT with no additional args (uses default logger)
-    SC_LOG_AT(sc_core::sc_log_level::INFO) << "SC_LOG_AT: No args, stream syntax";
-    SC_LOG_AT(sc_core::sc_log_level::WARN)("SC_LOG_AT: No args, format syntax: {}", 1);
+    SC_LOG_AT(sc_core::SC_HIGH) << "SC_LOG_AT: No args, stream syntax";
+    SC_LOG_AT(sc_core::SC_MEDIUM)("SC_LOG_AT: No args, format syntax: {}", 1);
     
     // SC_LOG_AT with logger handle
-    SC_LOG_AT(sc_core::sc_log_level::INFO, my_logger) << "SC_LOG_AT: With logger handle";
-    SC_LOG_AT(sc_core::sc_log_level::DEBUG, my_logger)("SC_LOG_AT: With logger handle, format: {}", 2);
+    SC_LOG_AT(sc_core::SC_HIGH, my_logger) << "SC_LOG_AT: With logger handle";
+    SC_LOG_AT(sc_core::SC_FULL, my_logger)("SC_LOG_AT: With logger handle, format: {}", 2);
     
     // SC_LOG_AT with explicit tag string
-    SC_LOG_AT(sc_core::sc_log_level::INFO, "ExplicitTag") << "SC_LOG_AT: With explicit tag";
-    SC_LOG_AT(sc_core::sc_log_level::TRACE, "ExplicitTag")("SC_LOG_AT: With explicit tag, format: {}", 3);
+    SC_LOG_AT(sc_core::SC_HIGH, "ExplicitTag") << "SC_LOG_AT: With explicit tag";
+    SC_LOG_AT(sc_core::SC_DEBUG, "ExplicitTag")("SC_LOG_AT: With explicit tag, format: {}", 3);
     
     // SC_LOG_AT with logger and tag
-    SC_LOG_AT(sc_core::sc_log_level::WARN, my_logger, "OverrideTag") << "SC_LOG_AT: Logger + override tag";
-    SC_LOG_AT(sc_core::sc_log_level::INFO, my_logger, "OverrideTag")("SC_LOG_AT: Logger + override tag, format: {}", 4);
+    SC_LOG_AT(sc_core::SC_MEDIUM, my_logger, "OverrideTag") << "SC_LOG_AT: Logger + override tag";
+    SC_LOG_AT(sc_core::SC_HIGH, my_logger, "OverrideTag")("SC_LOG_AT: Logger + override tag, format: {}", 4);
   }
 };
 
@@ -154,8 +166,8 @@ SC_MODULE(test_module_name_tag) {
   SC_CTOR(test_module_name_tag) {
     cout << "\n=== Test Using name() as Tag ===" << endl;
     
-    SC_LOG_AT(sc_core::sc_log_level::INFO, name()) << "Using name() as tag";
-    SC_LOG_AT(sc_core::sc_log_level::WARN, name())("Using name() as tag with format: {}", name());
+    SC_LOG_AT(sc_core::SC_HIGH, name()) << "Using name() as tag";
+    SC_LOG_AT(sc_core::SC_MEDIUM, name())("Using name() as tag with format: {}", name());
   }
 };
 
@@ -163,21 +175,21 @@ SC_MODULE(test_module_name_tag) {
 void test_global_loggers() {
   cout << "\n=== Test Global Static Loggers ===" << endl;
   
-  SC_INFO() << "INFO: Global default logger (no tag)";
-  SC_WARN()("WARN: Global default logger, format: {}", "test");
+  SC_NOTE() << "NOTE: Global default logger (no tag)";
+  SC_ALERT()("ALERT: Global default logger, format: {}", "test");
   
-  SC_INFO(GLOBAL_LOGGER_WITH_TAG) << "INFO: Global logger with tag";
-  SC_DEBUG(GLOBAL_LOGGER_WITH_TAG)("DEBUG: Global logger with tag, format: {}", 789);
+  SC_NOTE(GLOBAL_LOGGER_WITH_TAG) << "NOTE: Global logger with tag";
+  SC_DETAIL(GLOBAL_LOGGER_WITH_TAG)("DETAIL: Global logger with tag, format: {}", 789);
 }
 
 // Test 9: Tag-based logging (using string literals as tags)
 void test_tag_based_logging() {
   cout << "\n=== Test Tag-Based Logging ===" << endl;
   
-  SC_INFO("Tag1") << "INFO: Using Tag1";
-  SC_WARN("Tag2")("WARN: Using Tag2 with format: {}", "value");
-  SC_DEBUG("Tag3") << "DEBUG: Using Tag3";
-  SC_TRACE("Tag4")("TRACE: Using Tag4 with format: {}", 999);
+  SC_NOTE("Tag1") << "NOTE: Using Tag1";
+  SC_ALERT("Tag2")("ALERT: Using Tag2 with format: {}", "value");
+  SC_DETAIL("Tag3") << "DETAIL: Using Tag3";
+  SC_INTERNAL("Tag4")("INTERNAL: Using Tag4 with format: {}", 999);
 }
 
 // Test 10: All log levels
@@ -185,57 +197,57 @@ void test_all_log_levels() {
   cout << "\n=== Test All Log Levels ===" << endl;
   
   SC_CRITICAL("LevelTest") << "CRITICAL level test";
-  SC_WARN("LevelTest") << "WARN level test";
-  SC_INFO("LevelTest") << "INFO level test";
-  SC_DEBUG("LevelTest") << "DEBUG level test";
-  SC_TRACE("LevelTest") << "TRACE level test";
+  SC_ALERT("LevelTest") << "ALERT level test";
+  SC_NOTE("LevelTest") << "NOTE level test";
+  SC_DETAIL("LevelTest") << "DETAIL level test";
+  SC_INTERNAL("LevelTest") << "INTERNAL level test";
   
   SC_CRITICAL("LevelTest")("CRITICAL level test with format: {}", 1);
-  SC_WARN("LevelTest")("WARN level test with format: {}", 2);
-  SC_INFO("LevelTest")("INFO level test with format: {}", 3);
-  SC_DEBUG("LevelTest")("DEBUG level test with format: {}", 4);
-  SC_TRACE("LevelTest")("TRACE level test with format: {}", 5);
+  SC_ALERT("LevelTest")("ALERT level test with format: {}", 2);
+  SC_NOTE("LevelTest")("NOTE level test with format: {}", 3);
+  SC_DETAIL("LevelTest")("DETAIL level test with format: {}", 4);
+  SC_INTERNAL("LevelTest")("INTERNAL level test with format: {}", 5);
 }
 
 // Test 11: Complex format strings
 void test_complex_formats() {
   cout << "\n=== Test Complex Format Strings ===" << endl;
   
-  SC_INFO("FormatTest")("Multiple args: {}, {}, {}", 1, 2, 3);
-  SC_INFO("FormatTest")("Mixed types: int={}, str={}, float={:.2f}", 42, "hello", 3.14159);
-  SC_INFO("FormatTest")("Nested braces: {{}} and value: {}", 123);
-  SC_INFO("FormatTest")("Empty format string");
+  SC_NOTE("FormatTest")("Multiple args: {}, {}, {}", 1, 2, 3);
+  SC_NOTE("FormatTest")("Mixed types: int={}, str={}, float={:.2f}", 42, "hello", 3.14159);
+  SC_NOTE("FormatTest")("Nested braces: {{}} and value: {}", 123);
+  SC_NOTE("FormatTest")("Empty format string");
 }
 
 // Simple verbosity control for testing
 class test_verbosity_controller {
-  std::map<std::string, sc_core::sc_log_level> tag_levels;
+  std::map<std::string, sc_core::sc_verbosity> tag_levels;
   
 public:
   test_verbosity_controller() {
     // Set different levels for different tags
-    tag_levels["GlobalTag"] = sc_core::sc_log_level::INFO;
-    tag_levels["ModuleTag"] = sc_core::sc_log_level::DEBUG;
-    tag_levels["Logger1Tag"] = sc_core::sc_log_level::WARN;
-    tag_levels["Logger2Tag"] = sc_core::sc_log_level::TRACE;
-    tag_levels["VecLogger0"] = sc_core::sc_log_level::INFO;
-    tag_levels["VecLogger1"] = sc_core::sc_log_level::WARN;
-    tag_levels["VecLogger2"] = sc_core::sc_log_level::DEBUG;
-    tag_levels["LogAtTag"] = sc_core::sc_log_level::TRACE;
-    tag_levels["ExplicitTag"] = sc_core::sc_log_level::DEBUG;
-    tag_levels["OverrideTag"] = sc_core::sc_log_level::INFO;
-    tag_levels["Tag1"] = sc_core::sc_log_level::INFO;
-    tag_levels["Tag2"] = sc_core::sc_log_level::WARN;
-    tag_levels["Tag3"] = sc_core::sc_log_level::DEBUG;
-    tag_levels["Tag4"] = sc_core::sc_log_level::TRACE;
-    tag_levels["LevelTest"] = sc_core::sc_log_level::TRACE;
-    tag_levels["FormatTest"] = sc_core::sc_log_level::INFO;
+    tag_levels["GlobalTag"] = sc_core::SC_HIGH;
+    tag_levels["ModuleTag"] = sc_core::SC_FULL;
+    tag_levels["Logger1Tag"] = sc_core::SC_MEDIUM;
+    tag_levels["Logger2Tag"] = sc_core::SC_DEBUG;
+    tag_levels["VecLogger0"] = sc_core::SC_HIGH;
+    tag_levels["VecLogger1"] = sc_core::SC_MEDIUM;
+    tag_levels["VecLogger2"] = sc_core::SC_FULL;
+    tag_levels["LogAtTag"] = sc_core::SC_DEBUG;
+    tag_levels["ExplicitTag"] = sc_core::SC_FULL;
+    tag_levels["OverrideTag"] = sc_core::SC_HIGH;
+    tag_levels["Tag1"] = sc_core::SC_HIGH;
+    tag_levels["Tag2"] = sc_core::SC_MEDIUM;
+    tag_levels["Tag3"] = sc_core::SC_FULL;
+    tag_levels["Tag4"] = sc_core::SC_DEBUG;
+    tag_levels["LevelTest"] = sc_core::SC_DEBUG;
+    tag_levels["FormatTest"] = sc_core::SC_HIGH;
     
-    std::function<sc_core::sc_log_level(sc_core::sc_log_logger_cache &,
+    std::function<sc_core::sc_verbosity(sc_core::sc_log_logger_cache &,
                                         const char *, int, std::string_view)>
         fn = [&](sc_core::sc_log_logger_cache &logger, const char *file,
                  int line,
-                 std::string_view local_tag) -> sc_core::sc_log_level {
+                 std::string_view local_tag) -> sc_core::sc_verbosity {
       // Check if we have a specific level for this tag
       std::string tag_str;
       if (!logger.tag.empty()) {
@@ -248,17 +260,17 @@ public:
       
       auto it = tag_levels.find(tag_str);
       if (it != tag_levels.end()) {
-        if (logger.level == sc_core::sc_log_level::UNSET) {
+        if (logger.level == sc_core::SC_UNSET) {
           logger.level = it->second;
         }
         return it->second;
       }
       
       // Default to TRACE for everything else
-      if (logger.level == sc_core::sc_log_level::UNSET) {
-        logger.level = sc_core::sc_log_level::TRACE;
+      if (logger.level == sc_core::SC_UNSET) {
+        logger.level = sc_core::SC_DEBUG;
       }
-      return sc_core::sc_log_level::TRACE;
+      return sc_core::SC_DEBUG;
     };
     
     ::sc_core::sc_log_impl::sc_set_log_verbosity_fn(fn);
@@ -268,7 +280,7 @@ public:
 
 void report_handler(const sc_core::sc_report &rep,
                     const sc_core::sc_actions &actions) {
-  cout << "[" << sc_core::as_log(rep.get_verbosity()) << "] "
+  cout << "[" << level_name(sc_core::as_log(rep.get_verbosity())) << "] "
        << rep.get_msg_type() << ": " << rep.get_msg() << endl;
 }
 


### PR DESCRIPTION
sc_log: drop sc_log_level, drive macros off sc_verbosity, rename macro family
